### PR TITLE
Make JsonSerializerOptions.TypeInfoResolver nullable and mark as linker-safe.

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -706,10 +706,10 @@ namespace {@namespace}
 
                 sb.Append($@"
 
-private static {JsonPropertyInfoTypeRef}[] {propInitMethodName}({JsonSerializerContextTypeRef} context)
+private {JsonPropertyInfoTypeRef}[] {propInitMethodName}({JsonSerializerContextTypeRef}? context)
 {{
-    {contextTypeRef} {JsonContextVarName} = ({contextTypeRef})context;
-    {JsonSerializerOptionsTypeRef} options = context.Options;
+    {contextTypeRef} {JsonContextVarName} = ({contextTypeRef}?)context ?? this;
+    {JsonSerializerOptionsTypeRef} options = {JsonContextVarName}.Options;
 
     {JsonPropertyInfoTypeRef}[] {PropVarName} = {propertyArrayInstantiationValue};
 ");

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -50,6 +50,7 @@ namespace System.Text.Json.SourceGeneration
             private const string TypeTypeRef = "global::System.Type";
             private const string UnsafeTypeRef = "global::System.Runtime.CompilerServices.Unsafe";
             private const string NullableTypeRef = "global::System.Nullable";
+            private const string ConditionalWeakTableTypeRef = "global::System.Runtime.CompilerServices.ConditionalWeakTable";
             private const string EqualityComparerTypeRef = "global::System.Collections.Generic.EqualityComparer";
             private const string IListTypeRef = "global::System.Collections.Generic.IList";
             private const string KeyValuePairTypeRef = "global::System.Collections.Generic.KeyValuePair";
@@ -70,6 +71,7 @@ namespace System.Text.Json.SourceGeneration
             private const string JsonPropertyInfoTypeRef = "global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo";
             private const string JsonPropertyInfoValuesTypeRef = "global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues";
             private const string JsonTypeInfoTypeRef = "global::System.Text.Json.Serialization.Metadata.JsonTypeInfo";
+            private const string JsonTypeInfoResolverTypeRef = "global::System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver";
 
             private static DiagnosticDescriptor TypeNotSupported { get; } = new DiagnosticDescriptor(
                 id: "SYSLIB1030",
@@ -131,14 +133,14 @@ namespace System.Text.Json.SourceGeneration
                         isRootContextDef: true);
 
                     // Add GetJsonTypeInfo override implementation.
-                    AddSource($"{contextName}.GetJsonTypeInfo.g.cs", GetGetTypeInfoImplementation());
+                    AddSource($"{contextName}.GetJsonTypeInfo.g.cs", GetGetTypeInfoImplementation(), interfaceImplementation: JsonTypeInfoResolverTypeRef);
 
                     // Add property name initialization.
                     AddSource($"{contextName}.PropertyNames.g.cs", GetPropertyNameInitialization());
                 }
             }
 
-            private void AddSource(string fileName, string source, bool isRootContextDef = false)
+            private void AddSource(string fileName, string source, bool isRootContextDef = false, string? interfaceImplementation = null)
             {
                 string? generatedCodeAttributeSource = isRootContextDef ? s_generatedCodeAttributeSource : null;
 
@@ -175,7 +177,7 @@ namespace {@namespace}
 
                 // Add the core implementation for the derived context class.
                 string partialContextImplementation = $@"
-{generatedCodeAttributeSource}{declarationList[0]}
+{generatedCodeAttributeSource}{declarationList[0]}{(interfaceImplementation is null ? "" : ": " + interfaceImplementation)}
 {{
     {IndentSource(source, Math.Max(1, declarationCount - 1))}
 }}";
@@ -338,7 +340,7 @@ namespace {@namespace}
                             {{
                                 // Allow nullable handling to forward to the underlying type's converter.
                                 converter = {JsonMetadataServicesTypeRef}.GetNullableConverter<{typeCompilableName}>(this.{typeFriendlyName})!;
-                                converter = (({ JsonConverterFactoryTypeRef })converter).CreateConverter(typeToConvert, { OptionsInstanceVariableName })!;
+                                converter = (({JsonConverterFactoryTypeRef})converter).CreateConverter(typeToConvert, {OptionsInstanceVariableName})!;
                             }}
                             else
                             {{
@@ -356,7 +358,7 @@ namespace {@namespace}
                 }
 
                 metadataInitSource.Append($@"
-                    _{typeFriendlyName} = { JsonMetadataServicesTypeRef }.{ GetCreateValueInfoMethodRef(typeCompilableName)} ({ OptionsInstanceVariableName}, converter); ");
+                    _{typeFriendlyName} = {JsonMetadataServicesTypeRef}.{GetCreateValueInfoMethodRef(typeCompilableName)} ({OptionsInstanceVariableName}, converter); ");
 
                 return GenerateForType(typeMetadata, metadataInitSource.ToString());
             }
@@ -1176,6 +1178,10 @@ public {contextTypeName}({JsonSerializerOptionsTypeRef} options) : base(options)
 {{
 }}
 
+private {contextTypeName}({JsonSerializerOptionsTypeRef} options, bool bindOptionsToContext) : base(options, bindOptionsToContext)
+{{
+}}
+
 {GetFetchLogicForRuntimeSpecifiedCustomConverter()}");
 
                 if (_generateGetConverterMethodForProperties)
@@ -1291,9 +1297,27 @@ private {JsonConverterTypeRef} {GetConverterFromFactoryMethodName}({TypeTypeRef}
                     }
                 }
 
-                sb.Append(@"
+                sb.AppendLine(@"
     return null!;
 }");
+
+                // Explicit IJsonTypeInfoResolver implementation
+                string contextTypeName = _currentContext.ContextType.Name;
+
+                sb.AppendLine();
+                sb.Append(@$"{JsonTypeInfoTypeRef}? {JsonTypeInfoResolverTypeRef}.GetTypeInfo({TypeTypeRef} type, {JsonSerializerOptionsTypeRef} options)
+{{
+    {contextTypeName} context = this;
+
+    if (options != null && {OptionsInstanceVariableName} != options)
+    {{
+        context = (s_resolverCache ??= new()).GetValue(options, static options => new {contextTypeName}(options, bindOptionsToContext: false));
+    }}
+
+    return context.GetTypeInfo(type);
+}}
+
+private {ConditionalWeakTableTypeRef}<{JsonSerializerOptionsTypeRef},{contextTypeName}>? s_resolverCache;");
 
                 return sb.ToString();
             }

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -357,6 +357,13 @@ namespace System.Text.Json
         public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
         public System.Text.Json.Serialization.ReferenceHandler? ReferenceHandler { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration> PolymorphicTypeConfigurations { get { throw null; } }
+        public System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver TypeInfoResolver
+        {
+            [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+            [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+            get { throw null; }
+            set { }
+        }
         public System.Text.Json.Serialization.JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }
         public void AddContext<TContext>() where TContext : System.Text.Json.Serialization.JsonSerializerContext, new() { }
@@ -950,12 +957,13 @@ namespace System.Text.Json.Serialization
         public string? TypeInfoPropertyName { get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonSourceGenerationMode GenerationMode { get { throw null; } set { } }
     }
-    public abstract partial class JsonSerializerContext
+    public abstract partial class JsonSerializerContext : System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver
     {
         protected JsonSerializerContext(System.Text.Json.JsonSerializerOptions? options) { }
         protected abstract System.Text.Json.JsonSerializerOptions? GeneratedSerializerOptions { get; }
         public System.Text.Json.JsonSerializerOptions Options { get { throw null; } }
         public abstract System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type);
+        System.Text.Json.Serialization.Metadata.JsonTypeInfo System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver.GetTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = false)]
     public sealed partial class JsonSourceGenerationOptionsAttribute : System.Text.Json.Serialization.JsonAttribute
@@ -1044,6 +1052,20 @@ namespace System.Text.Json.Serialization
 }
 namespace System.Text.Json.Serialization.Metadata
 {
+    public class DefaultJsonTypeInfoResolver : System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public DefaultJsonTypeInfoResolver() { }
+
+        public virtual System.Text.Json.Serialization.Metadata.JsonTypeInfo GetTypeInfo(System.Type type, System.Text.Json.JsonSerializerOptions options) { throw null; }
+
+        public System.Collections.Generic.IList<System.Action<System.Text.Json.Serialization.Metadata.JsonTypeInfo>> Modifiers { get; }
+    }
+    public interface IJsonTypeInfoResolver
+    {
+        System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type, System.Text.Json.JsonSerializerOptions options);
+    }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class JsonCollectionInfoValues<TCollection>
     {
@@ -1138,10 +1160,17 @@ namespace System.Text.Json.Serialization.Metadata
         public System.Type ParameterType { get { throw null; } init { } }
         public int Position { get { throw null; } init { } }
     }
-    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class JsonPropertyInfo
     {
         internal JsonPropertyInfo() { }
+        public System.Text.Json.Serialization.JsonConverter? CustomConverter { get { throw null; } set { } }
+        public System.Func<object, object?>? Get { get { throw null; } set { } }
+        public string Name { get { throw null; } set { } }
+        public System.Text.Json.Serialization.JsonNumberHandling? NumberHandling { get { throw null; } set { } }
+        public System.Type PropertyType { get { throw null; } }
+        public System.Text.Json.JsonSerializerOptions Options { get { throw null; } }
+        public System.Action<object, object?>? Set { get { throw null; } set { } }
+        public System.Func<object, object?, bool>? ShouldSerialize { get { throw null; } set { } }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class JsonPropertyInfoValues<T>
@@ -1162,15 +1191,38 @@ namespace System.Text.Json.Serialization.Metadata
         public System.Text.Json.Serialization.Metadata.JsonTypeInfo PropertyTypeInfo { get { throw null; } init { } }
         public System.Action<object, T?>? Setter { get { throw null; } init { } }
     }
-    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public partial class JsonTypeInfo
+    public static class JsonTypeInfoResolver
+    {
+        public static System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver Combine(params System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver[] resolvers) { throw null; }
+    }
+    public abstract partial class JsonTypeInfo
     {
         internal JsonTypeInfo() { }
+        public System.Text.Json.JsonSerializerOptions Options { get { throw null; } }
+        public System.Collections.Generic.IList<System.Text.Json.Serialization.Metadata.JsonPropertyInfo> Properties { get { throw null; } }
+        public System.Type Type { get { throw null; } }
+        public System.Text.Json.Serialization.JsonConverter Converter { get { throw null; } }
+        public System.Func<object>? CreateObject { get { throw null; } set { } }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfoKind Kind { get { throw null; } }
+        public System.Text.Json.Serialization.JsonNumberHandling? NumberHandling { get { throw null; } set { } }
+        public static System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> CreateJsonTypeInfo<T>(System.Text.Json.JsonSerializerOptions options) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
+        public static System.Text.Json.Serialization.Metadata.JsonTypeInfo CreateJsonTypeInfo(System.Type type, System.Text.Json.JsonSerializerOptions options) { throw null; }
+        public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name) { throw null; }
     }
-    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class JsonTypeInfo<T> : System.Text.Json.Serialization.Metadata.JsonTypeInfo
     {
         internal JsonTypeInfo() { }
+        public new System.Func<T>? CreateObject { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Action<System.Text.Json.Utf8JsonWriter, T>? SerializeHandler { get { throw null; } }
+    }
+    public enum JsonTypeInfoKind
+    {
+        None = 0,
+        Object = 1,
+        Enumerable = 2,
+        Dictionary = 3
     }
 }

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -960,6 +960,7 @@ namespace System.Text.Json.Serialization
     public abstract partial class JsonSerializerContext : System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver
     {
         protected JsonSerializerContext(System.Text.Json.JsonSerializerOptions? options) { }
+        protected JsonSerializerContext(System.Text.Json.JsonSerializerOptions? options, bool bindOptionsToContext) { }
         protected abstract System.Text.Json.JsonSerializerOptions? GeneratedSerializerOptions { get; }
         public System.Text.Json.JsonSerializerOptions Options { get { throw null; } }
         public abstract System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type);

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -357,13 +357,7 @@ namespace System.Text.Json
         public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
         public System.Text.Json.Serialization.ReferenceHandler? ReferenceHandler { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration> PolymorphicTypeConfigurations { get { throw null; } }
-        public System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver TypeInfoResolver
-        {
-            [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
-            [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
-            get { throw null; }
-            set { }
-        }
+        public System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver? TypeInfoResolver { get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }
         public void AddContext<TContext>() where TContext : System.Text.Json.Serialization.JsonSerializerContext, new() { }

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -243,6 +243,15 @@
   <data name="JsonElementHasWrongType" xml:space="preserve">
     <value>The requested operation requires an element of type '{0}', but the target element has type '{1}'.</value>
   </data>
+  <data name="TypeInfoResolverImmutable" xml:space="preserve">
+    <value>Default TypeInfoResolver and custom TypeInfoResolver after first usage cannot be changed.</value>
+  </data>
+  <data name="TypeInfoImmutable" xml:space="preserve">
+    <value>JsonTypeInfo cannot be changed after first usage.</value>
+  </data>
+  <data name="PropertyInfoImmutable" xml:space="preserve">
+    <value>JsonPropertyInfo cannot be changed after first usage.</value>
+  </data>
   <data name="MaxDepthMustBePositive" xml:space="preserve">
     <value>Max depth must be positive.</value>
   </data>
@@ -389,6 +398,12 @@
   </data>
   <data name="SerializationConverterNotCompatible" xml:space="preserve">
     <value>The converter '{0}' is not compatible with the type '{1}'.</value>
+  </data>
+  <data name="ResolverTypeNotCompatible" xml:space="preserve">
+    <value>TypeInfoResolver expected to return JsonTypeInfo of type '{0}' but returned JsonTypeInfo of type '{1}'.</value>
+  </data>
+  <data name="ResolverTypeInfoOptionsNotCompatible" xml:space="preserve">
+    <value>TypeInfoResolver expected to return JsonTypeInfo options bound to the JsonSerializerOptions provided in the argument.</value>
   </data>
   <data name="SerializationConverterWrite" xml:space="preserve">
     <value>The converter '{0}' wrote too much or not enough.</value>
@@ -572,13 +587,13 @@
   <data name="NoMetadataForType" xml:space="preserve">
     <value>Metadata for type '{0}' was not provided to the serializer. The serializer method used does not support reflection-based creation of serialization-related type metadata. If using source generation, ensure that all root types passed to the serializer have been indicated with 'JsonSerializableAttribute', along with any types that might be serialized polymorphically.</value>
   </data>
-  <data name="NodeCollectionIsReadOnly" xml:space="preserve">
+  <data name="CollectionIsReadOnly" xml:space="preserve">
     <value>Collection is read-only.</value>
   </data>
-  <data name="NodeArrayIndexNegative" xml:space="preserve">
+  <data name="ArrayIndexNegative" xml:space="preserve">
     <value>Number was less than 0.</value>
   </data>
-  <data name="NodeArrayTooSmall" xml:space="preserve">
+  <data name="ArrayTooSmall" xml:space="preserve">
     <value>Destination array was not long enough.</value>
   </data>
   <data name="NodeJsonObjectCustomConverterNotAllowedOnExtensionProperty" xml:space="preserve">
@@ -637,5 +652,8 @@
   </data>
   <data name="Polymorphism_RuntimeTypeDiamondAmbiguity" xml:space="preserve">
     <value>Runtime type '{0}' has a diamond ambiguity between derived types '{1}' and '{2}' of polymorphic type '{3}'. Consider either removing one of the derived types or removing the 'JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor' setting.</value>
+  </data>
+  <data name="JsonTypeInfoOperationNotPossibleForKindNone" xml:space="preserve">
+    <value>Operation is not possible when Kind is JsonTypeKind.None.</value>
   </data>
 </root>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -69,6 +69,7 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
     <Compile Include="System\Text\Json\JsonHelpers.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Date.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Escaping.cs" />
+    <Compile Include="System\Text\Json\JsonPropertyDictionary.ValueList.cs" />
     <Compile Include="System\Text\Json\JsonPropertyDictionary.cs" />
     <Compile Include="System\Text\Json\JsonPropertyDictionary.KeyCollection.cs" />
     <Compile Include="System\Text\Json\JsonPropertyDictionary.ValueCollection.cs" />
@@ -109,6 +110,7 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPolymorphicAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPropertyNameAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPropertyOrderAttribute.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\CastingConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ImmutableDictionaryOfTKeyTValueConverterWithReflection.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ImmutableEnumerableOfTConverterWithReflection.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\StackOrQueueConverterWithReflection.cs" />
@@ -127,6 +129,12 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Write.Node.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializerContext.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonUnknownDerivedTypeHandling.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\DefaultJsonTypeInfoResolver.Converters.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\DefaultJsonTypeInfoResolver.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\JsonTypeInfoResolver.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\IJsonTypeInfoResolver.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\JsonTypeInfoKind.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\CustomJsonTypeInfoOfT.cs" />
     <Compile Include="System\Text\Json\Serialization\PolymorphicSerializationState.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPolymorphicTypeConfiguration.cs" />
     <Compile Include="System\Text\Json\Serialization\ReferenceEqualsWrapper.cs" />
@@ -383,12 +391,7 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
   </ItemGroup>
 
   <ItemGroup>
-    <AnalyzerReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn3.11.csproj"
-                       Pack="true"
-                       ReferenceAnalyzer="false"
-                       Condition="'$(DotNetBuildFromSource)' != 'true'" />
-    <AnalyzerReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn4.0.csproj"
-                       Pack="true"
-                       ReferenceAnalyzer="false" />
+    <AnalyzerReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn3.11.csproj" Pack="true" ReferenceAnalyzer="false" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+    <AnalyzerReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn4.0.csproj" Pack="true" ReferenceAnalyzer="false" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.KeyCollection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.KeyCollection.cs
@@ -36,9 +36,9 @@ namespace System.Text.Json
                 }
             }
 
-            public void Add(string propertyName) => ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            public void Add(string propertyName) => ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
 
-            public void Clear() => ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            public void Clear() => ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
 
             public bool Contains(string propertyName) => _parent.ContainsProperty(propertyName);
 
@@ -46,14 +46,14 @@ namespace System.Text.Json
             {
                 if (index < 0)
                 {
-                    ThrowHelper.ThrowArgumentOutOfRangeException_NodeArrayIndexNegative(nameof(index));
+                    ThrowHelper.ThrowArgumentOutOfRangeException_ArrayIndexNegative(nameof(index));
                 }
 
                 foreach (KeyValuePair<string, T?> item in _parent)
                 {
                     if (index >= propertyNameArray.Length)
                     {
-                        ThrowHelper.ThrowArgumentException_NodeArrayTooSmall(nameof(propertyNameArray));
+                        ThrowHelper.ThrowArgumentException_ArrayTooSmall(nameof(propertyNameArray));
                     }
 
                     propertyNameArray[index++] = item.Key;
@@ -68,7 +68,7 @@ namespace System.Text.Json
                 }
             }
 
-            bool ICollection<string>.Remove(string propertyName) => throw ThrowHelper.GetNotSupportedException_NodeCollectionIsReadOnly();
+            bool ICollection<string>.Remove(string propertyName) => throw ThrowHelper.GetNotSupportedException_CollectionIsReadOnly();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.ValueCollection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.ValueCollection.cs
@@ -36,9 +36,9 @@ namespace System.Text.Json
                 }
             }
 
-            public void Add(T? jsonNode) => ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            public void Add(T? jsonNode) => ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
 
-            public void Clear() => ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+            public void Clear() => ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
 
             public bool Contains(T? jsonNode) => _parent.ContainsValue(jsonNode);
 
@@ -46,14 +46,14 @@ namespace System.Text.Json
             {
                 if (index < 0)
                 {
-                    ThrowHelper.ThrowArgumentOutOfRangeException_NodeArrayIndexNegative(nameof(index));
+                    ThrowHelper.ThrowArgumentOutOfRangeException_ArrayIndexNegative(nameof(index));
                 }
 
                 foreach (KeyValuePair<string, T?> item in _parent)
                 {
                     if (index >= nodeArray.Length)
                     {
-                        ThrowHelper.ThrowArgumentException_NodeArrayTooSmall(nameof(nodeArray));
+                        ThrowHelper.ThrowArgumentException_ArrayTooSmall(nameof(nodeArray));
                     }
 
                     nodeArray[index++] = item.Value;
@@ -68,7 +68,7 @@ namespace System.Text.Json
                 }
             }
 
-            bool ICollection<T?>.Remove(T? node) => throw ThrowHelper.GetNotSupportedException_NodeCollectionIsReadOnly();
+            bool ICollection<T?>.Remove(T? node) => throw ThrowHelper.GetNotSupportedException_CollectionIsReadOnly();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.ValueList.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.ValueList.cs
@@ -1,0 +1,207 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Text.Json
+{
+    internal sealed partial class JsonPropertyDictionary<T>
+    {
+#if DEBUG
+        // CreateEditableValueList should be called at most once by JsonTypeInfo
+        private ValueList? _editableValueList;
+#endif
+
+        public ValueList CreateValueList(Func<T, string>? getKey)
+        {
+            ValueList ret = new ValueList(this, getKey);
+#if DEBUG
+            Debug.Assert(_editableValueList == null, "More than one ValueList created");
+            return _editableValueList ??= ret;
+#else
+            return ret;
+#endif
+        }
+
+        internal sealed class ValueList : IList<T>
+        {
+            private readonly JsonPropertyDictionary<T> _parent;
+            private Func<T, string>? _getKey;
+            private List<T>? _items;
+
+            [MemberNotNullWhen(false, nameof(_getKey))]
+            [MemberNotNullWhen(false, nameof(_items))]
+            public bool IsReadOnly => _getKey == null;
+            public int Count => IsReadOnly ? _parent.Count : _items.Count;
+
+            public T this[int index]
+            {
+                get => IsReadOnly ? _parent.List[index].Value! : _items[index];
+                set
+                {
+                    if (IsReadOnly)
+                        ThrowCollectionIsReadOnly();
+
+                    _items[index] = value;
+                }
+            }
+
+            public ValueList(JsonPropertyDictionary<T> jsonObject, Func<T, string>? getKey)
+            {
+                // _getKey == null is equivalent to being read-only
+                _parent = jsonObject;
+                _getKey = getKey;
+
+                Debug.Assert(!_parent.IsReadOnly, $"{nameof(JsonPropertyDictionary<T>)} is read-only but editable value list is created");
+
+                if (!IsReadOnly)
+                {
+                    // We cannot ensure keys won't change while editing therefore we operate on the internal copy.
+                    // Once we're done editing FinishEditingAndMakeReadOnly should be called then we switch to operating directly on _parent
+                    _items = new List<T>(_parent.Count);
+                    foreach (var kv in _parent.List)
+                    {
+                        Debug.Assert(kv.Value != null, $"{nameof(JsonPropertyDictionary<T>)} contains null value");
+                        _items.Add(kv.Value);
+                    }
+                }
+            }
+
+            public void FinishEditingAndMakeReadOnly()
+            {
+                Debug.Assert(!IsReadOnly, $"{nameof(FinishEditingAndMakeReadOnly)} called on read-only ValueList");
+
+                // We do not know if any of the keys needs to be updated therefore we need to re-create cache
+                _parent.Clear();
+
+                foreach (var item in _items)
+                {
+                    _parent.AddValue(_getKey(item), item);
+                }
+
+                // clearing those so that we don't keep GC from freeing
+                _items = null;
+                _getKey = null;
+            }
+
+            public void Add(T item)
+            {
+                if (IsReadOnly)
+                    ThrowCollectionIsReadOnly();
+
+                _items.Add(item);
+            }
+
+            public void Clear()
+            {
+                if (IsReadOnly)
+                    ThrowCollectionIsReadOnly();
+
+                _items.Clear();
+            }
+
+            public bool Contains(T item) => IsReadOnly ? _parent.ContainsValue(item) : _items.Contains(item);
+
+            public void CopyTo(T[] array, int index)
+            {
+                if (index < 0)
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException_ArrayIndexNegative(nameof(index));
+                }
+
+                if (IsReadOnly)
+                {
+                    foreach (KeyValuePair<string, T?> item in _parent)
+                    {
+                        if (index >= array.Length)
+                        {
+                            ThrowHelper.ThrowArgumentException_ArrayTooSmall(nameof(array));
+                        }
+
+                        array[index++] = item.Value!;
+                    }
+                }
+                else
+                {
+                    _items.CopyTo(array, index);
+                }
+            }
+
+            public int IndexOf(T item)
+            {
+                if (IsReadOnly)
+                {
+                    int index = 0;
+                    foreach (var kv in _parent.List)
+                    {
+                        if (kv.Value == item)
+                        {
+                            return index;
+                        }
+
+                        index++;
+                    }
+
+                    return -1;
+                }
+                else
+                {
+                    return _items.IndexOf(item);
+                }
+            }
+
+            public void Insert(int index, T item)
+            {
+                if (IsReadOnly)
+                    ThrowCollectionIsReadOnly();
+
+                _items.Insert(index, item);
+            }
+
+            public bool Remove(T item)
+            {
+                if (IsReadOnly)
+                    ThrowCollectionIsReadOnly();
+
+                return _items.Remove(item);
+            }
+
+            public void RemoveAt(int index)
+            {
+                if (IsReadOnly)
+                    ThrowCollectionIsReadOnly();
+
+                _items.RemoveAt(index);
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                if (IsReadOnly)
+                {
+                    foreach (KeyValuePair<string, T?> item in _parent)
+                    {
+                        yield return item.Value!;
+                    }
+                }
+                else
+                {
+                    foreach (T item in _items)
+                    {
+                        yield return item;
+                    }
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            [DoesNotReturn]
+            private static void ThrowCollectionIsReadOnly()
+            {
+                ThrowHelper.ThrowInvalidOperationException_CollectionIsReadOnly();
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
@@ -38,7 +38,7 @@ namespace System.Text.Json
         {
             if (IsReadOnly)
             {
-                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+                ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
             }
 
             if (propertyName == null)
@@ -53,7 +53,7 @@ namespace System.Text.Json
         {
             if (IsReadOnly)
             {
-                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+                ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
             }
 
             Add(property.Key, property.Value);
@@ -63,7 +63,7 @@ namespace System.Text.Json
         {
             if (IsReadOnly)
             {
-                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+                ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
             }
 
             // A check for a null propertyName is not required since this method is only called by internal code.
@@ -76,7 +76,7 @@ namespace System.Text.Json
         {
             if (IsReadOnly)
             {
-                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+                ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
             }
 
             _propertyList.Clear();
@@ -105,7 +105,7 @@ namespace System.Text.Json
         {
             if (IsReadOnly)
             {
-                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+                ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
             }
 
             if (propertyName == null)
@@ -133,14 +133,14 @@ namespace System.Text.Json
         {
             if (index < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException_NodeArrayIndexNegative(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException_ArrayIndexNegative(nameof(index));
             }
 
             foreach (KeyValuePair<string, T?> item in _propertyList)
             {
                 if (index >= array.Length)
                 {
-                    ThrowHelper.ThrowArgumentException_NodeArrayTooSmall(nameof(array));
+                    ThrowHelper.ThrowArgumentException_ArrayTooSmall(nameof(array));
                 }
 
                 array[index++] = item;
@@ -211,7 +211,7 @@ namespace System.Text.Json
         {
             if (IsReadOnly)
             {
-                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+                ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
             }
 
             if (propertyName == null)
@@ -286,7 +286,7 @@ namespace System.Text.Json
         {
             if (IsReadOnly)
             {
-                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+                ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
             }
 
             CreateDictionaryIfThresholdMet();
@@ -383,7 +383,7 @@ namespace System.Text.Json
         {
             if (IsReadOnly)
             {
-                ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
+                ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
             }
 
             if (_propertyDictionary != null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    /// <summary>
+    /// Converter wrapper which casts SourceType into TargetType
+    /// </summary>
+    internal sealed class CastingConverter<TargetType, SourceType> : JsonConverter<TargetType>
+    {
+        private JsonConverter<SourceType> _sourceConverter;
+
+        internal override Type? KeyType => _sourceConverter.KeyType;
+        internal override Type? ElementType => _sourceConverter.ElementType;
+
+        public override bool HandleNull => _sourceConverter.HandleNull;
+        internal override ConverterStrategy ConverterStrategy => _sourceConverter.ConverterStrategy;
+
+        internal CastingConverter(JsonConverter<SourceType> sourceConverter) : base(initialize: false)
+        {
+            _sourceConverter = sourceConverter;
+            Initialize();
+
+            IsInternalConverter = sourceConverter.IsInternalConverter;
+            IsInternalConverterForNumberType = sourceConverter.IsInternalConverterForNumberType;
+            RequiresReadAhead = sourceConverter.RequiresReadAhead;
+            CanUseDirectReadOrWrite = sourceConverter.CanUseDirectReadOrWrite;
+        }
+
+        public override TargetType? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => ConvertToTarget(_sourceConverter.Read(ref reader, typeToConvert, options));
+
+        public override void Write(Utf8JsonWriter writer, TargetType value, JsonSerializerOptions options)
+            => _sourceConverter.Write(writer, ConvertToSource(value), options);
+
+        internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, ref ReadStack state, out TargetType? value)
+        {
+            bool ret = _sourceConverter.OnTryRead(ref reader, typeToConvert, options, ref state, out SourceType? sourceValue);
+            value = ConvertToTarget(sourceValue);
+            return ret;
+        }
+
+        internal override bool OnTryWrite(Utf8JsonWriter writer, TargetType value, JsonSerializerOptions options, ref WriteStack state)
+            => _sourceConverter.OnTryWrite(writer, ConvertToSource(value), options, ref state);
+
+        public override TargetType ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => ConvertToTarget(_sourceConverter.ReadAsPropertyName(ref reader, typeToConvert, options));
+
+        internal override TargetType ReadAsPropertyNameCore(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => ConvertToTarget(_sourceConverter.ReadAsPropertyNameCore(ref reader, typeToConvert, options));
+
+        public override void WriteAsPropertyName(Utf8JsonWriter writer, TargetType value, JsonSerializerOptions options)
+            => _sourceConverter.WriteAsPropertyName(writer, ConvertToSource(value), options);
+
+        internal override void WriteAsPropertyNameCore(Utf8JsonWriter writer, TargetType value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)
+            => _sourceConverter.WriteAsPropertyNameCore(writer, ConvertToSource(value), options, isWritingExtensionDataProperty);
+
+        internal override TargetType ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling, JsonSerializerOptions options)
+            => ConvertToTarget(_sourceConverter.ReadNumberWithCustomHandling(ref reader, handling, options));
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, TargetType value, JsonNumberHandling handling)
+            => _sourceConverter.WriteNumberWithCustomHandling(writer, ConvertToSource(value), handling);
+
+        private static SourceType ConvertToSource(TargetType? targetValue)
+            => (SourceType)(object?)targetValue!;
+
+        private static TargetType ConvertToTarget(SourceType? sourceValue)
+            => (TargetType)(object?)sourceValue!;
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -41,7 +41,7 @@ namespace System.Text.Json.Serialization
                 }
             }
 
-            state.Current.ReturnValue = typeInfo.CreateObject()!;
+            state.Current.ReturnValue = typeInfo.CreateObject();
             Debug.Assert(state.Current.ReturnValue is TCollection);
         }
 
@@ -49,7 +49,7 @@ namespace System.Text.Json.Serialization
 
         protected static JsonConverter<TElement> GetElementConverter(JsonTypeInfo elementTypeInfo)
         {
-            JsonConverter<TElement> converter = (JsonConverter<TElement>)elementTypeInfo.PropertyInfoForTypeInfo.ConverterBase;
+            JsonConverter<TElement> converter = (JsonConverter<TElement>)elementTypeInfo.Converter;
             Debug.Assert(converter != null); // It should not be possible to have a null converter at this point.
 
             return converter;
@@ -57,7 +57,7 @@ namespace System.Text.Json.Serialization
 
         protected static JsonConverter<TElement> GetElementConverter(ref WriteStack state)
         {
-            JsonConverter<TElement> converter = (JsonConverter<TElement>)state.Current.JsonPropertyInfo!.ConverterBase;
+            JsonConverter<TElement> converter = (JsonConverter<TElement>)state.Current.JsonPropertyInfo!.EffectiveConverter;
             Debug.Assert(converter != null); // It should not be possible to have a null converter at this point.
 
             return converter;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -70,7 +70,7 @@ namespace System.Text.Json.Serialization
 
         protected static JsonConverter<T> GetConverter<T>(JsonTypeInfo typeInfo)
         {
-            JsonConverter<T> converter = (JsonConverter<T>)typeInfo.PropertyInfoForTypeInfo.ConverterBase;
+            JsonConverter<T> converter = (JsonConverter<T>)typeInfo.Converter;
             Debug.Assert(converter != null); // It should not be possible to have a null converter at this point.
 
             return converter;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverter.cs
@@ -21,7 +21,7 @@ namespace System.Text.Json.Serialization.Converters
         protected sealed override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             JsonTypeInfo typeInfo = state.Current.JsonTypeInfo;
-            JsonTypeInfo.ConstructorDelegate? constructorDelegate = typeInfo.CreateObject;
+            Func<object>? constructorDelegate = typeInfo.CreateObject;
 
             if (constructorDelegate == null)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -67,7 +67,7 @@ namespace System.Text.Json.Serialization.Converters
                 jsonTypeInfo is JsonTypeInfo<T> info &&
                 info.SerializeHandler != null &&
                 !state.CurrentContainsMetadata && // Do not use the fast path if state needs to write metadata.
-                info.Options.JsonSerializerContext?.CanUseSerializationLogic == true)
+                info.Options.SerializerContext?.CanUseSerializationLogic == true)
             {
                 info.SerializeHandler(writer, value);
                 return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -36,7 +36,7 @@ namespace System.Text.Json.Serialization.Converters
                     ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(jsonTypeInfo.Type, ref reader, ref state);
                 }
 
-                obj = jsonTypeInfo.CreateObject!()!;
+                obj = jsonTypeInfo.CreateObject()!;
 
                 if (obj is IJsonOnDeserializing onDeserializing)
                 {
@@ -132,7 +132,7 @@ namespace System.Text.Json.Serialization.Converters
                         ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(jsonTypeInfo.Type, ref reader, ref state);
                     }
 
-                    obj = jsonTypeInfo.CreateObject!()!;
+                    obj = jsonTypeInfo.CreateObject()!;
 
                     if (state.Current.MetadataPropertyNames.HasFlag(MetadataPropertyName.Id))
                     {
@@ -206,7 +206,7 @@ namespace System.Text.Json.Serialization.Converters
 
                     if (state.Current.PropertyState < StackFramePropertyState.ReadValue)
                     {
-                        if (!jsonPropertyInfo.ShouldDeserialize)
+                        if (!jsonPropertyInfo.CanDeserialize)
                         {
                             if (!reader.TrySkip())
                             {
@@ -301,7 +301,7 @@ namespace System.Text.Json.Serialization.Converters
                 for (int i = 0; i < properties.Count; i++)
                 {
                     JsonPropertyInfo jsonPropertyInfo = properties[i].Value!;
-                    if (jsonPropertyInfo.ShouldSerialize)
+                    if (jsonPropertyInfo.CanSerialize)
                     {
                         // Remember the current property for JsonPath support if an exception is thrown.
                         state.Current.JsonPropertyInfo = jsonPropertyInfo;
@@ -317,7 +317,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 // Write extension data after the normal properties.
                 JsonPropertyInfo? dataExtensionProperty = jsonTypeInfo.DataExtensionProperty;
-                if (dataExtensionProperty?.ShouldSerialize == true)
+                if (dataExtensionProperty?.CanSerialize == true)
                 {
                     // Remember the current property for JsonPath support if an exception is thrown.
                     state.Current.JsonPropertyInfo = dataExtensionProperty;
@@ -355,14 +355,14 @@ namespace System.Text.Json.Serialization.Converters
                 {
                     JsonPropertyInfo? jsonPropertyInfo = propertyList![state.Current.EnumeratorIndex].Value;
                     Debug.Assert(jsonPropertyInfo != null);
-                    if (jsonPropertyInfo.ShouldSerialize)
+                    if (jsonPropertyInfo.CanSerialize)
                     {
                         state.Current.JsonPropertyInfo = jsonPropertyInfo;
                         state.Current.NumberHandling = jsonPropertyInfo.EffectiveNumberHandling;
 
                         if (!jsonPropertyInfo.GetMemberAndWriteJson(obj!, ref state, writer))
                         {
-                            Debug.Assert(jsonPropertyInfo.ConverterBase.ConverterStrategy != ConverterStrategy.Value);
+                            Debug.Assert(jsonPropertyInfo.EffectiveConverter.ConverterStrategy != ConverterStrategy.Value);
                             return false;
                         }
 
@@ -384,7 +384,7 @@ namespace System.Text.Json.Serialization.Converters
                 if (state.Current.EnumeratorIndex == propertyList.Count)
                 {
                     JsonPropertyInfo? dataExtensionProperty = jsonTypeInfo.DataExtensionProperty;
-                    if (dataExtensionProperty?.ShouldSerialize == true)
+                    if (dataExtensionProperty?.CanSerialize == true)
                     {
                         // Remember the current property for JsonPath support if an exception is thrown.
                         state.Current.JsonPropertyInfo = dataExtensionProperty;
@@ -434,7 +434,7 @@ namespace System.Text.Json.Serialization.Converters
             bool useExtensionProperty)
         {
             // Skip the property if not found.
-            if (!jsonPropertyInfo.ShouldDeserialize)
+            if (!jsonPropertyInfo.CanDeserialize)
             {
                 reader.Skip();
             }
@@ -464,7 +464,7 @@ namespace System.Text.Json.Serialization.Converters
 
             if (!state.Current.UseExtensionProperty)
             {
-                if (!SingleValueReadWithReadAhead(jsonPropertyInfo.ConverterBase.RequiresReadAhead, ref reader, ref state))
+                if (!SingleValueReadWithReadAhead(jsonPropertyInfo.EffectiveConverter.RequiresReadAhead, ref reader, ref state))
                 {
                     return false;
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -289,7 +289,7 @@ namespace System.Text.Json.Serialization.Converters
                         out _,
                         createExtensionProperty: false);
 
-                    if (jsonPropertyInfo.ShouldDeserialize)
+                    if (jsonPropertyInfo.CanDeserialize)
                     {
                         ArgumentState argumentState = state.Current.CtorArgumentState!;
 
@@ -454,7 +454,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             if (state.Current.PropertyState < StackFramePropertyState.ReadValue)
             {
-                if (!jsonPropertyInfo.ShouldDeserialize)
+                if (!jsonPropertyInfo.CanDeserialize)
                 {
                     if (!reader.TrySkip())
                     {
@@ -488,7 +488,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
             }
 
-            Debug.Assert(jsonPropertyInfo.ShouldDeserialize);
+            Debug.Assert(jsonPropertyInfo.CanDeserialize);
 
             // Ensure that the cache has enough capacity to add this property.
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Text.Json.Serialization.Converters;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization
@@ -68,6 +70,13 @@ namespace System.Text.Json.Serialization
         internal abstract JsonPropertyInfo CreateJsonPropertyInfo();
 
         internal abstract JsonParameterInfo CreateJsonParameterInfo();
+
+        internal virtual JsonConverter<TargetType> CreateCastingConverter<TargetType>()
+        {
+            // This can only happen for factory converters and we should always expand factory here.
+            ThrowHelper.ThrowInvalidOperationException_ConverterCanConvertMultipleTypes(typeof(TargetType), this);
+            return null!;
+        }
 
         internal abstract Type? ElementType { get; }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -18,6 +18,19 @@ namespace System.Text.Json.Serialization
         /// </summary>
         protected internal JsonConverter()
         {
+            Initialize();
+        }
+
+        internal JsonConverter(bool initialize)
+        {
+            if (initialize)
+            {
+                Initialize();
+            }
+        }
+
+        internal void Initialize()
+        {
             IsValueType = typeof(T).IsValueType;
             IsInternalConverter = GetType().Assembly == typeof(JsonConverter).Assembly;
 
@@ -62,6 +75,11 @@ namespace System.Text.Json.Serialization
         internal override sealed JsonParameterInfo CreateJsonParameterInfo()
         {
             return new JsonParameterInfo<T>();
+        }
+
+        internal override sealed JsonConverter<TargetType> CreateCastingConverter<TargetType>()
+        {
+            return new CastingConverter<TargetType, T>(this);
         }
 
         internal override Type? KeyType => null;
@@ -318,7 +336,7 @@ namespace System.Text.Json.Serialization
                 state.Current.PolymorphicSerializationState != PolymorphicSerializationState.PolymorphicReEntryStarted)
             {
                 JsonTypeInfo jsonTypeInfo = state.PeekNestedJsonTypeInfo();
-                Debug.Assert(jsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase.TypeToConvert == TypeToConvert);
+                Debug.Assert(jsonTypeInfo.Converter.TypeToConvert == TypeToConvert);
 
                 bool canBePolymorphic = CanBePolymorphic || jsonTypeInfo.PolymorphicTypeResolver is not null;
                 JsonConverter? polymorphicConverter = canBePolymorphic ?
@@ -528,7 +546,11 @@ namespace System.Text.Json.Serialization
         /// <remarks>Method should be overridden in custom converters of types used in deserialized dictionary keys.</remarks>
         public virtual T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (!IsInternalConverter && options.TryGetDefaultSimpleConverter(TypeToConvert, out JsonConverter? defaultConverter))
+            if (!IsInternalConverter &&
+                options.SerializerContext is null && // For consistency do not return any default converters for
+                                                     // options instances linked to a JsonSerializerContext,
+                                                     // even if the default converters might have been rooted.
+                DefaultJsonTypeInfoResolver.TryGetDefaultSimpleConverter(TypeToConvert, out JsonConverter? defaultConverter))
             {
                 // .NET 5 backward compatibility: hardcode the default converter for primitive key serialization.
                 Debug.Assert(defaultConverter.IsInternalConverter && defaultConverter is JsonConverter<T>);
@@ -562,7 +584,11 @@ namespace System.Text.Json.Serialization
         /// <remarks>Method should be overridden in custom converters of types used in serialized dictionary keys.</remarks>
         public virtual void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
-            if (!IsInternalConverter && options.TryGetDefaultSimpleConverter(TypeToConvert, out JsonConverter? defaultConverter))
+            if (!IsInternalConverter &&
+                options.SerializerContext is null && // For consistency do not return any default converters for
+                                                     // options instances linked to a JsonSerializerContext,
+                                                     // even if the default converters might have been rooted.
+                DefaultJsonTypeInfoResolver.TryGetDefaultSimpleConverter(TypeToConvert, out JsonConverter? defaultConverter))
             {
                 // .NET 5 backward compatibility: hardcode the default converter for primitive key serialization.
                 Debug.Assert(defaultConverter.IsInternalConverter && defaultConverter is JsonConverter<T>);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -121,12 +121,16 @@ namespace System.Text.Json
                     genericArgs[1].UnderlyingSystemType == typeof(JsonElement) ||
                     genericArgs[1].UnderlyingSystemType == typeof(Nodes.JsonNode));
 #endif
-                if (jsonPropertyInfo.JsonTypeInfo.CreateObject == null)
+
+                Func<object>? createObjectForExtensionDataProp = jsonPropertyInfo.JsonTypeInfo.CreateObject
+                    ?? jsonPropertyInfo.JsonTypeInfo.CreateObjectForExtensionDataProperty;
+
+                if (createObjectForExtensionDataProp == null)
                 {
                     // Avoid a reference to the JsonNode type for trimming
                     if (jsonPropertyInfo.PropertyType.FullName == JsonTypeInfo.JsonObjectTypeName)
                     {
-                        extensionData = jsonPropertyInfo.ConverterBase.CreateObject(options);
+                        extensionData = jsonPropertyInfo.EffectiveConverter.CreateObject(options);
                     }
                     else
                     {
@@ -135,7 +139,7 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    extensionData = jsonPropertyInfo.JsonTypeInfo.CreateObject();
+                    extensionData = createObjectForExtensionDataProp();
                 }
 
                 jsonPropertyInfo.SetExtensionDictionaryAsObject(obj, extensionData);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
@@ -35,7 +35,7 @@ namespace System.Text.Json
             state.Initialize(jsonTypeInfo);
 
             TValue? value;
-            JsonConverter jsonConverter = jsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase;
+            JsonConverter jsonConverter = jsonTypeInfo.Converter;
 
             // For performance, the code below is a lifted ReadCore() above.
             if (jsonConverter is JsonConverter<TValue> converter)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -440,7 +440,7 @@ namespace System.Text.Json
                         ref bufferState,
                         ref jsonReaderState,
                         ref readStack,
-                        queueTypeInfo.PropertyInfoForTypeInfo.ConverterBase,
+                        queueTypeInfo.Converter,
                         options);
 
                     if (readStack.Current.ReturnValue is Queue<TValue> queue)
@@ -469,7 +469,7 @@ namespace System.Text.Json
             ReadStack readStack = default;
             jsonTypeInfo.EnsureConfigured();
             readStack.Initialize(jsonTypeInfo, supportContinuation: true);
-            JsonConverter converter = readStack.Current.JsonPropertyInfo!.ConverterBase;
+            JsonConverter converter = readStack.Current.JsonPropertyInfo!.EffectiveConverter;
             var jsonReaderState = new JsonReaderState(options.GetReaderOptions());
 
             try
@@ -500,7 +500,7 @@ namespace System.Text.Json
             ReadStack readStack = default;
             jsonTypeInfo.EnsureConfigured();
             readStack.Initialize(jsonTypeInfo, supportContinuation: true);
-            JsonConverter converter = readStack.Current.JsonPropertyInfo!.ConverterBase;
+            JsonConverter converter = readStack.Current.JsonPropertyInfo!.EffectiveConverter;
             var jsonReaderState = new JsonReaderState(options.GetReaderOptions());
 
             try

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
@@ -422,7 +422,7 @@ namespace System.Text.Json
 
                 var newReader = new Utf8JsonReader(rentedSpan, originalReaderOptions);
 
-                JsonConverter jsonConverter = state.Current.JsonPropertyInfo!.ConverterBase;
+                JsonConverter jsonConverter = state.Current.JsonPropertyInfo!.EffectiveConverter;
                 TValue? value = ReadCore<TValue>(jsonConverter, ref newReader, jsonTypeInfo.Options, ref state);
 
                 // The reader should have thrown if we have remaining bytes.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -41,7 +41,7 @@ namespace System.Text.Json
 
             if (jsonTypeInfo.HasSerialize &&
                 jsonTypeInfo is JsonTypeInfo<TValue> typedInfo &&
-                typedInfo.Options.JsonSerializerContext?.CanUseSerializationLogic == true)
+                typedInfo.Options.SerializerContext?.CanUseSerializationLogic == true)
             {
                 Debug.Assert(typedInfo.SerializeHandler != null);
                 typedInfo.SerializeHandler(writer, value);
@@ -59,15 +59,15 @@ namespace System.Text.Json
 
             Debug.Assert(!jsonTypeInfo.HasSerialize ||
                 jsonTypeInfo is not JsonTypeInfo<TValue> ||
-                jsonTypeInfo.Options.JsonSerializerContext == null ||
-                !jsonTypeInfo.Options.JsonSerializerContext.CanUseSerializationLogic,
+                jsonTypeInfo.Options.SerializerContext == null ||
+                !jsonTypeInfo.Options.SerializerContext.CanUseSerializationLogic,
                 "Incorrect method called. WriteUsingGeneratedSerializer() should have been called instead.");
 
             WriteStack state = default;
             jsonTypeInfo.EnsureConfigured();
             state.Initialize(jsonTypeInfo, supportContinuation: false, supportAsync: false);
 
-            JsonConverter converter = jsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase;
+            JsonConverter converter = jsonTypeInfo.Converter;
             Debug.Assert(converter != null);
             Debug.Assert(jsonTypeInfo.Options != null);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -101,6 +101,7 @@ namespace System.Text.Json.Serialization
                 if (bindOptionsToContext)
                 {
                     options.TypeInfoResolver = this;
+                    Debug.Assert(_options == options, "options.TypeInfoResolver setter did not assign options");
                 }
                 else
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization
@@ -8,7 +9,7 @@ namespace System.Text.Json.Serialization
     /// <summary>
     /// Provides metadata about a set of types that is relevant to JSON serialization.
     /// </summary>
-    public abstract partial class JsonSerializerContext
+    public abstract partial class JsonSerializerContext : IJsonTypeInfoResolver
     {
         private bool? _canUseSerializationLogic;
 
@@ -19,9 +20,9 @@ namespace System.Text.Json.Serialization
         /// when instanciating the context, then a new instance is bound and returned.
         /// </summary>
         /// <remarks>
-        /// The instance cannot be mutated once it is bound with the context instance.
+        /// The instance cannot be mutated once it is bound to the context instance.
         /// </remarks>
-        public JsonSerializerOptions Options => _options ??= new JsonSerializerOptions { JsonSerializerContext = this };
+        public JsonSerializerOptions Options => _options ??= new JsonSerializerOptions { TypeInfoResolver = this };
 
         /// <summary>
         /// Indicates whether pre-generated serialization logic for types in the context
@@ -83,8 +84,7 @@ namespace System.Text.Json.Serialization
         {
             if (options != null)
             {
-                options.JsonSerializerContext = this;
-                _options = options;
+                options.TypeInfoResolver = this;
             }
         }
 
@@ -94,5 +94,16 @@ namespace System.Text.Json.Serialization
         /// <param name="type">The type to fetch metadata about.</param>
         /// <returns>The metadata for the specified type, or <see langword="null" /> if the context has no metadata for the type.</returns>
         public abstract JsonTypeInfo? GetTypeInfo(Type type);
+
+        JsonTypeInfo? IJsonTypeInfoResolver.GetTypeInfo(Type type, JsonSerializerOptions options)
+        {
+            if (options != null && _options != options)
+            {
+                // TODO is this the appropriate exception message to throw?
+                ThrowHelper.ThrowInvalidOperationException_SerializerContextOptionsImmutable();
+            }
+
+            return GetTypeInfo(type);
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -81,10 +81,31 @@ namespace System.Text.Json.Serialization
         /// or until <see cref="Options"/> is called, where a new options instance is created and bound.
         /// </remarks>
         protected JsonSerializerContext(JsonSerializerOptions? options)
+            : this(options, bindOptionsToContext: true)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="JsonSerializerContext"/> and optionally binds it with the indicated <see cref="JsonSerializerOptions"/>.
+        /// </summary>
+        /// <param name="options">The run time provided options for the context instance.</param>
+        /// <param name="bindOptionsToContext">Specify whether the options <paramref name="options"/> instance should be bound to the new context.</param>
+        /// <remarks>
+        /// If no instance options are passed, then no options are set until the context is bound using <see cref="JsonSerializerOptions.AddContext{TContext}"/>,
+        /// or until <see cref="Options"/> is called, where a new options instance is created and bound.
+        /// </remarks>
+        protected JsonSerializerContext(JsonSerializerOptions? options, bool bindOptionsToContext)
         {
             if (options != null)
             {
-                options.TypeInfoResolver = this;
+                if (bindOptionsToContext)
+                {
+                    options.TypeInfoResolver = this;
+                }
+                else
+                {
+                    _options = options;
+                }
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 using System.Text.Json.Reflection;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Converters;
@@ -19,127 +18,6 @@ namespace System.Text.Json
     /// </summary>
     public sealed partial class JsonSerializerOptions
     {
-        // The global list of built-in simple converters.
-        private static Dictionary<Type, JsonConverter>? s_defaultSimpleConverters;
-
-        // The global list of built-in converters that override CanConvert().
-        private static JsonConverter[]? s_defaultFactoryConverters;
-
-        // Stores the JsonTypeInfo factory, which requires unreferenced code and must be rooted by the reflection-based serializer.
-        private static Func<Type, JsonSerializerOptions, JsonTypeInfo>? s_typeInfoCreationFunc;
-
-        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        private static void RootReflectionSerializerDependencies()
-        {
-            // s_typeInfoCreationFunc is the last field assigned.
-            // Use it as the sentinel to ensure that all dependencies are initialized.
-            if (Volatile.Read(ref s_typeInfoCreationFunc) is null)
-            {
-                s_defaultSimpleConverters = GetDefaultSimpleConverters();
-                s_defaultFactoryConverters = GetDefaultFactoryConverters();
-                // Explicitly ensure that the previous fields are initialized along with this one.
-                Volatile.Write(ref s_typeInfoCreationFunc, CreateJsonTypeInfo);
-            }
-
-            [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-            [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-            static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options)
-            {
-                JsonTypeInfo.ValidateType(type, null, null, options);
-
-                MethodInfo methodInfo = typeof(JsonSerializerOptions).GetMethod(nameof(CreateReflectionJsonTypeInfo), BindingFlags.NonPublic | BindingFlags.Instance)!;
-#if NETCOREAPP
-                return (JsonTypeInfo)methodInfo.MakeGenericMethod(type).Invoke(options, BindingFlags.NonPublic | BindingFlags.DoNotWrapExceptions, null, null, null)!;
-#else
-                try
-                {
-                    return (JsonTypeInfo)methodInfo.MakeGenericMethod(type).Invoke(options, null)!;
-                }
-                catch (TargetInvocationException ex)
-                {
-                    // Some of the validation is done during construction (i.e. validity of JsonConverter, inner types etc.)
-                    // therefore we need to unwrap TargetInvocationException for better user experience
-                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                    throw null!;
-                }
-#endif
-            }
-        }
-
-        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        private JsonTypeInfo<T> CreateReflectionJsonTypeInfo<T>()
-        {
-            return new ReflectionJsonTypeInfo<T>(this);
-        }
-
-        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        private static JsonConverter[] GetDefaultFactoryConverters()
-        {
-            return new JsonConverter[]
-            {
-                // Check for disallowed types.
-                new UnsupportedTypeConverterFactory(),
-                // Nullable converter should always be next since it forwards to any nullable type.
-                new NullableConverterFactory(),
-                new EnumConverterFactory(),
-                new JsonNodeConverterFactory(),
-                new FSharpTypeConverterFactory(),
-                // IAsyncEnumerable takes precedence over IEnumerable.
-                new IAsyncEnumerableConverterFactory(),
-                // IEnumerable should always be second to last since they can convert any IEnumerable.
-                new IEnumerableConverterFactory(),
-                // Object should always be last since it converts any type.
-                new ObjectConverterFactory()
-            };
-        }
-
-        private static Dictionary<Type, JsonConverter> GetDefaultSimpleConverters()
-        {
-            const int NumberOfSimpleConverters = 26;
-            var converters = new Dictionary<Type, JsonConverter>(NumberOfSimpleConverters);
-
-            // Use a dictionary for simple converters.
-            // When adding to this, update NumberOfSimpleConverters above.
-            Add(JsonMetadataServices.BooleanConverter);
-            Add(JsonMetadataServices.ByteConverter);
-            Add(JsonMetadataServices.ByteArrayConverter);
-            Add(JsonMetadataServices.CharConverter);
-            Add(JsonMetadataServices.DateTimeConverter);
-            Add(JsonMetadataServices.DateTimeOffsetConverter);
-#if NETCOREAPP
-            Add(JsonMetadataServices.DateOnlyConverter);
-            Add(JsonMetadataServices.TimeOnlyConverter);
-#endif
-            Add(JsonMetadataServices.DoubleConverter);
-            Add(JsonMetadataServices.DecimalConverter);
-            Add(JsonMetadataServices.GuidConverter);
-            Add(JsonMetadataServices.Int16Converter);
-            Add(JsonMetadataServices.Int32Converter);
-            Add(JsonMetadataServices.Int64Converter);
-            Add(JsonMetadataServices.JsonElementConverter);
-            Add(JsonMetadataServices.JsonDocumentConverter);
-            Add(JsonMetadataServices.ObjectConverter);
-            Add(JsonMetadataServices.SByteConverter);
-            Add(JsonMetadataServices.SingleConverter);
-            Add(JsonMetadataServices.StringConverter);
-            Add(JsonMetadataServices.TimeSpanConverter);
-            Add(JsonMetadataServices.UInt16Converter);
-            Add(JsonMetadataServices.UInt32Converter);
-            Add(JsonMetadataServices.UInt64Converter);
-            Add(JsonMetadataServices.UriConverter);
-            Add(JsonMetadataServices.VersionConverter);
-
-            Debug.Assert(converters.Count <= NumberOfSimpleConverters);
-
-            return converters;
-
-            void Add(JsonConverter converter) =>
-                converters.Add(converter.TypeToConvert, converter);
-        }
-
         /// <summary>
         /// The list of custom converters.
         /// </summary>
@@ -156,11 +34,11 @@ namespace System.Text.Json
         /// </remarks>
         public IList<JsonPolymorphicTypeConfiguration> PolymorphicTypeConfigurations => _polymorphicTypeConfigurations;
 
-        internal JsonConverter GetConverterFromMember(Type? parentClassType, Type propertyType, MemberInfo? memberInfo)
+        // This may return factory converter
+        internal JsonConverter? GetCustomConverterFromMember(Type? parentClassType, Type typeToConvert, MemberInfo? memberInfo)
         {
-            JsonConverter converter = null!;
+            JsonConverter? converter = null;
 
-            // Priority 1: attempt to get converter from JsonConverterAttribute on property.
             if (memberInfo != null)
             {
                 Debug.Assert(parentClassType != null);
@@ -170,24 +48,41 @@ namespace System.Text.Json
 
                 if (converterAttribute != null)
                 {
-                    converter = GetConverterFromAttribute(converterAttribute, typeToConvert: propertyType, classTypeAttributeIsOn: parentClassType!, memberInfo);
+                    converter = GetConverterFromAttribute(converterAttribute, typeToConvert, classTypeAttributeIsOn: parentClassType!, memberInfo);
                 }
             }
 
-            if (converter == null)
-            {
-                converter = GetConverterInternal(propertyType);
-                Debug.Assert(converter != null);
-            }
+            return converter;
+        }
 
+        internal JsonConverter GetConverterForType(Type typeToConvert)
+        {
+            JsonConverter converter = GetConverterInternal(typeToConvert);
+            Debug.Assert(converter != null);
+
+            converter = ExpandFactoryConverter(converter, typeToConvert);
+
+            CheckConverterNullabilityIsSameAsPropertyType(converter, typeToConvert);
+
+            return converter;
+        }
+
+        [return: NotNullIfNotNull("converter")]
+        internal JsonConverter? ExpandFactoryConverter(JsonConverter? converter, Type typeToConvert)
+        {
             if (converter is JsonConverterFactory factory)
             {
-                converter = factory.GetConverterInternal(propertyType, this);
+                converter = factory.GetConverterInternal(typeToConvert, this);
 
                 // A factory cannot return null; GetConverterInternal checked for that.
                 Debug.Assert(converter != null);
             }
 
+            return converter;
+        }
+
+        internal static void CheckConverterNullabilityIsSameAsPropertyType(JsonConverter converter, Type propertyType)
+        {
             // User has indicated that either:
             //   a) a non-nullable-struct handling converter should handle a nullable struct type or
             //   b) a nullable-struct handling converter should handle a non-nullable struct type.
@@ -201,8 +96,6 @@ namespace System.Text.Json
             {
                 ThrowHelper.ThrowInvalidOperationException_ConverterCanConvertMultipleTypes(propertyType, converter);
             }
-
-            return converter;
         }
 
         /// <summary>
@@ -228,7 +121,7 @@ namespace System.Text.Json
                 ThrowHelper.ThrowArgumentNullException(nameof(typeToConvert));
             }
 
-            RootReflectionSerializerDependencies();
+            DefaultJsonTypeInfoResolver.RootDefaultInstance();
             return GetConverterInternal(typeToConvert);
         }
 
@@ -243,12 +136,12 @@ namespace System.Text.Json
             return GetConverterFromType(typeToConvert);
         }
 
-        private JsonConverter GetConverterFromType(Type typeToConvert)
+        internal JsonConverter GetConverterFromType(Type typeToConvert)
         {
             Debug.Assert(typeToConvert != null);
 
             // Priority 1: If there is a JsonSerializerContext, fetch the converter from there.
-            JsonConverter? converter = _serializerContext?.GetTypeInfo(typeToConvert)?.PropertyInfoForTypeInfo?.ConverterBase;
+            JsonConverter? converter = SerializerContext?.GetTypeInfo(typeToConvert)?.Converter;
 
             // Priority 2: Attempt to get custom converter added at runtime.
             // Currently there is not a way at runtime to override the [JsonConverter] when applied to a property.
@@ -276,35 +169,7 @@ namespace System.Text.Json
             // Priority 4: Attempt to get built-in converter.
             if (converter == null)
             {
-                if (s_defaultSimpleConverters == null || s_defaultFactoryConverters == null)
-                {
-                    // (De)serialization using serializer's options-based methods has not yet occurred, so the built-in converters are not rooted.
-                    // Even though source-gen code paths do not call this method <i.e. JsonSerializerOptions.GetConverter(Type)>, we do not root all the
-                    // built-in converters here since we fetch converters for any type included for source generation from the binded context (Priority 1).
-                    Debug.Assert(s_defaultSimpleConverters == null);
-                    Debug.Assert(s_defaultFactoryConverters == null);
-                    ThrowHelper.ThrowNotSupportedException_BuiltInConvertersNotRooted(typeToConvert);
-                    return null!;
-                }
-
-                if (s_defaultSimpleConverters.TryGetValue(typeToConvert, out JsonConverter? foundConverter))
-                {
-                    converter = foundConverter;
-                }
-                else
-                {
-                    foreach (JsonConverter item in s_defaultFactoryConverters)
-                    {
-                        if (item.CanConvert(typeToConvert))
-                        {
-                            converter = item;
-                            break;
-                        }
-                    }
-
-                    // Since the object and IEnumerable converters cover all types, we should have a converter.
-                    Debug.Assert(converter != null);
-                }
+                converter = DefaultJsonTypeInfoResolver.GetDefaultConverter(typeToConvert);
             }
 
             // Allow redirection for generic types or the enum converter.
@@ -374,21 +239,6 @@ namespace System.Text.Json
             }
 
             return converter;
-        }
-
-        internal bool TryGetDefaultSimpleConverter(Type typeToConvert, [NotNullWhen(true)] out JsonConverter? converter)
-        {
-            if (_serializerContext == null && // For consistency do not return any default converters for
-                                    // options instances linked to a JsonSerializerContext,
-                                    // even if the default converters might have been rooted.
-                s_defaultSimpleConverters != null &&
-                s_defaultSimpleConverters.TryGetValue(typeToConvert, out converter))
-            {
-                return true;
-            }
-
-            converter = null;
-            return false;
         }
 
         private static Attribute? GetAttributeThatCanHaveMultiple(Type classType, Type attributeType, MemberInfo memberInfo)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -9,7 +10,6 @@ using System.Text.Encodings.Web;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
-using System.Threading;
 
 namespace System.Text.Json
 {
@@ -35,7 +35,7 @@ namespace System.Text.Json
         public static JsonSerializerOptions Default { get; } = CreateDefaultImmutableInstance();
 
         // For any new option added, adding it to the options copied in the copy constructor below must be considered.
-        private JsonSerializerContext? _serializerContext;
+        private IJsonTypeInfoResolver? _typeInfoResolver;
         private MemberAccessor? _memberAccessorStrategy;
         private JsonNamingPolicy? _dictionaryKeyPolicy;
         private JsonNamingPolicy? _jsonPropertyNamingPolicy;
@@ -43,9 +43,7 @@ namespace System.Text.Json
         private ReferenceHandler? _referenceHandler;
         private JavaScriptEncoder? _encoder;
         private ConfigurationList<JsonConverter> _converters;
-#pragma warning disable CA2252 // This API requires opting into preview features
         private ConfigurationList<JsonPolymorphicTypeConfiguration> _polymorphicTypeConfigurations;
-#pragma warning restore CA2252 // This API requires opting into preview features
         private JsonIgnoreCondition _defaultIgnoreCondition;
         private JsonNumberHandling _numberHandling;
         private JsonUnknownTypeHandling _unknownTypeHandling;
@@ -60,20 +58,15 @@ namespace System.Text.Json
         private bool _propertyNameCaseInsensitive;
         private bool _writeIndented;
 
+        private bool _isLockedInstance;
+
         /// <summary>
         /// Constructs a new <see cref="JsonSerializerOptions"/> instance.
         /// </summary>
         public JsonSerializerOptions()
         {
-            _converters = new ConfigurationList<JsonConverter>(this);
-
-#pragma warning disable CA2252 // This API requires opting into preview features
-            _polymorphicTypeConfigurations = new ConfigurationList<JsonPolymorphicTypeConfiguration>(this)
-            {
-                OnElementAdded = static config => { config.IsAssignedToOptionsInstance = true; }
-            };
-#pragma warning restore CA2252 // This API requires opting into preview features
-
+            _converters = new ConverterList(this);
+            _polymorphicTypeConfigurations = new PolymorphicConfigurationList(this);
             TrackOptionsInstance(this);
         }
 
@@ -96,10 +89,8 @@ namespace System.Text.Json
             _jsonPropertyNamingPolicy = options._jsonPropertyNamingPolicy;
             _readCommentHandling = options._readCommentHandling;
             _referenceHandler = options._referenceHandler;
-            _converters = new ConfigurationList<JsonConverter>(this, options._converters);
-#pragma warning disable CA2252 // This API requires opting into preview features
-            _polymorphicTypeConfigurations = new ConfigurationList<JsonPolymorphicTypeConfiguration>(this, options._polymorphicTypeConfigurations);
-#pragma warning restore CA2252 // This API requires opting into preview features
+            _converters = new ConverterList(this, options._converters);
+            _polymorphicTypeConfigurations = new PolymorphicConfigurationList(this, options._polymorphicTypeConfigurations);
             _encoder = options._encoder;
             _defaultIgnoreCondition = options._defaultIgnoreCondition;
             _numberHandling = options._numberHandling;
@@ -114,7 +105,9 @@ namespace System.Text.Json
             _includeFields = options._includeFields;
             _propertyNameCaseInsensitive = options._propertyNameCaseInsensitive;
             _writeIndented = options._writeIndented;
-
+            // Preserve backward compatibility with .NET 6
+            // This should almost certainly be changed, cf. https://github.com/dotnet/aspnetcore/issues/38720
+            _typeInfoResolver = options._typeInfoResolver is JsonSerializerContext ? null : options._typeInfoResolver;
             EffectiveMaxDepth = options.EffectiveMaxDepth;
             ReferenceHandlingStrategy = options.ReferenceHandlingStrategy;
 
@@ -166,8 +159,46 @@ namespace System.Text.Json
         {
             VerifyMutable();
             TContext context = new();
-            _serializerContext = context;
+            _typeInfoResolver = context;
+            _isLockedInstance = true;
             context._options = this;
+        }
+
+        /// <summary>
+        /// Gets or sets JsonTypeInfo resolver.
+        /// </summary>
+        public IJsonTypeInfoResolver TypeInfoResolver
+        {
+            [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+            [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+            get
+            {
+                return _typeInfoResolver ?? DefaultJsonTypeInfoResolver.RootDefaultInstance();
+            }
+            set
+            {
+                VerifyMutable();
+
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                if (value is JsonSerializerContext ctx)
+                {
+                    if (ctx._options != null && ctx._options != this)
+                    {
+                        // TODO evaluate if this is the appropriate behaviour;
+                        ThrowHelper.ThrowInvalidOperationException_SerializerContextOptionsImmutable();
+                    }
+
+                    // Associate options instance with context and lock for further modification
+                    ctx._options = this;
+                    _isLockedInstance = true;
+                }
+
+                _typeInfoResolver = value;
+            }
         }
 
         /// <summary>
@@ -559,15 +590,7 @@ namespace System.Text.Json
             }
         }
 
-        internal JsonSerializerContext? JsonSerializerContext
-        {
-            get => _serializerContext;
-            set
-            {
-                VerifyMutable();
-                _serializerContext = value;
-            }
-        }
+        internal JsonSerializerContext? SerializerContext => _typeInfoResolver as JsonSerializerContext;
 
         // The cached value used to determine if ReferenceHandler should use Preserve or IgnoreCycles semanitcs or None of them.
         internal ReferenceHandlingStrategy ReferenceHandlingStrategy = ReferenceHandlingStrategy.None;
@@ -596,42 +619,58 @@ namespace System.Text.Json
             }
         }
 
-        /// <summary>
-        /// Whether the options instance has been primed for reflection-based serialization.
-        /// </summary>
-        internal bool IsInitializedForReflectionSerializer;
+        internal bool IsInitializedForReflectionSerializer { get; private set; }
+        // Effective resolver, populated when enacting reflection-based fallback
+        // Should not be taken into account when calculating options equality.
+        private IJsonTypeInfoResolver? _effectiveJsonTypeInfoResolver;
 
         /// <summary>
         /// Initializes the converters for the reflection-based serializer.
-        /// <seealso cref="InitializeForReflectionSerializer"/> must be checked before calling.
         /// </summary>
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
         internal void InitializeForReflectionSerializer()
         {
-            RootReflectionSerializerDependencies();
-            Volatile.Write(ref IsInitializedForReflectionSerializer, true);
-            if (_cachingContext != null)
+            if (_typeInfoResolver is JsonSerializerContext ctx)
             {
-                _cachingContext.Options.IsInitializedForReflectionSerializer = true;
+                // .NET 6 backward compatibility; use fallback to reflection serialization
+                // TODO: Consider removing this behaviour (needs to be filed as a breaking change).
+                _effectiveJsonTypeInfoResolver = JsonTypeInfoResolver.Combine(ctx, DefaultJsonTypeInfoResolver.RootDefaultInstance());
             }
+            else
+            {
+                _typeInfoResolver ??= DefaultJsonTypeInfoResolver.RootDefaultInstance();
+            }
+
+            if (_cachingContext != null && _cachingContext.Options != this)
+            {
+                // We're using a shared caching context deriving from a different options instance;
+                // for coherence ensure that it has been opted in for reflection-based serialization as well.
+                _cachingContext.Options.InitializeForReflectionSerializer();
+            }
+
+            IsInitializedForReflectionSerializer = true;
         }
 
         private JsonTypeInfo GetJsonTypeInfoFromContextOrCreate(Type type)
         {
-            JsonTypeInfo? info = _serializerContext?.GetTypeInfo(type);
-            if (info == null && IsInitializedForReflectionSerializer)
-            {
-                Debug.Assert(
-                    s_typeInfoCreationFunc != null,
-                    "Reflection-based JsonTypeInfo creator should be initialized if IsInitializedForReflectionSerializer is true.");
-                info = s_typeInfoCreationFunc(type, this);
-            }
+            IJsonTypeInfoResolver? resolver = _effectiveJsonTypeInfoResolver ?? _typeInfoResolver;
+            JsonTypeInfo? info = resolver?.GetTypeInfo(type, this);
 
             if (info == null)
             {
                 ThrowHelper.ThrowNotSupportedException_NoMetadataForType(type);
                 return null!;
+            }
+
+            if (info.Type != type)
+            {
+                ThrowHelper.ThrowInvalidOperationException_ResolverTypeNotCompatible(type, info.Type);
+            }
+
+            if (info.Options != this)
+            {
+                ThrowHelper.ThrowInvalidOperationException_ResolverTypeInfoOptionsNotCompatible();
             }
 
             info.EnsureConfigured();
@@ -681,16 +720,44 @@ namespace System.Text.Json
 
         internal void VerifyMutable()
         {
-            if (_cachingContext != null || _serializerContext != null)
+            if (_isLockedInstance)
             {
-                ThrowHelper.ThrowInvalidOperationException_SerializerOptionsImmutable(_serializerContext);
+                ThrowHelper.ThrowInvalidOperationException_SerializerOptionsImmutable(_typeInfoResolver as JsonSerializerContext);
             }
+        }
+
+        private sealed class ConverterList : ConfigurationList<JsonConverter>
+        {
+            private readonly JsonSerializerOptions _options;
+
+            public ConverterList(JsonSerializerOptions options, IList<JsonConverter>? source = null)
+                : base(source)
+            {
+                _options = options;
+            }
+
+            protected override bool IsLockedInstance => _options._isLockedInstance;
+            protected override void VerifyMutable() => _options.VerifyMutable();
+        }
+
+        private sealed class PolymorphicConfigurationList : ConfigurationList<JsonPolymorphicTypeConfiguration>
+        {
+            private readonly JsonSerializerOptions _options;
+
+            public PolymorphicConfigurationList(JsonSerializerOptions options, IList<JsonPolymorphicTypeConfiguration>? source = null)
+                : base(source)
+            {
+                _options = options;
+            }
+
+            protected override bool IsLockedInstance => _options._isLockedInstance;
+            protected override void VerifyMutable() => _options.VerifyMutable();
+            protected override void OnItemAdded(JsonPolymorphicTypeConfiguration config) => config.IsAssignedToOptionsInstance = true;
         }
 
         private static JsonSerializerOptions CreateDefaultImmutableInstance()
         {
-            var options = new JsonSerializerOptions();
-            options.InitializeCachingContext(); // eagerly initialize caching context to close type for modification.
+            var options = new JsonSerializerOptions { _isLockedInstance = true };
             return options;
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -167,22 +167,15 @@ namespace System.Text.Json
         /// <summary>
         /// Gets or sets JsonTypeInfo resolver.
         /// </summary>
-        public IJsonTypeInfoResolver TypeInfoResolver
+        public IJsonTypeInfoResolver? TypeInfoResolver
         {
-            [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-            [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
             get
             {
-                return _typeInfoResolver ?? DefaultJsonTypeInfoResolver.RootDefaultInstance();
+                return _typeInfoResolver;
             }
             set
             {
                 VerifyMutable();
-
-                if (value is null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
 
                 if (value is JsonSerializerContext ctx)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.Json.Serialization.Converters;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    /// <summary>
+    /// Creates and initializes serialization metadata for a type.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal sealed class CustomJsonTypeInfo<T> : JsonTypeInfo<T>
+    {
+        /// <summary>
+        /// Creates serialization metadata for a type using a simple converter.
+        /// </summary>
+        internal CustomJsonTypeInfo(JsonSerializerOptions options)
+            : base(GetEffectiveConverter(
+                    typeof(T),
+                    parentClassType: null, // A TypeInfo never has a "parent" class.
+                    memberInfo: null, // A TypeInfo never has a "parent" property.
+                    options),
+                  options)
+        {
+        }
+
+        internal override JsonParameterInfoValues[] GetParameterInfoValues()
+        {
+            // Parametrized constructors not supported yet for custom types
+            return Array.Empty<JsonParameterInfoValues>();
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Converters;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    public partial class DefaultJsonTypeInfoResolver
+    {
+        private static Dictionary<Type, JsonConverter>? s_defaultSimpleConverters;
+        private static JsonConverterFactory[]? s_defaultFactoryConverters;
+
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        private static JsonConverterFactory[] GetDefaultFactoryConverters()
+        {
+            return new JsonConverterFactory[]
+            {
+                // Check for disallowed types.
+                new UnsupportedTypeConverterFactory(),
+                // Nullable converter should always be next since it forwards to any nullable type.
+                new NullableConverterFactory(),
+                new EnumConverterFactory(),
+                new JsonNodeConverterFactory(),
+                new FSharpTypeConverterFactory(),
+                // IAsyncEnumerable takes precedence over IEnumerable.
+                new IAsyncEnumerableConverterFactory(),
+                // IEnumerable should always be second to last since they can convert any IEnumerable.
+                new IEnumerableConverterFactory(),
+                // Object should always be last since it converts any type.
+                new ObjectConverterFactory()
+            };
+        }
+
+        private static Dictionary<Type, JsonConverter> GetDefaultSimpleConverters()
+        {
+            const int NumberOfSimpleConverters = 26;
+            var converters = new Dictionary<Type, JsonConverter>(NumberOfSimpleConverters);
+
+            // Use a dictionary for simple converters.
+            // When adding to this, update NumberOfSimpleConverters above.
+            Add(JsonMetadataServices.BooleanConverter);
+            Add(JsonMetadataServices.ByteConverter);
+            Add(JsonMetadataServices.ByteArrayConverter);
+            Add(JsonMetadataServices.CharConverter);
+            Add(JsonMetadataServices.DateTimeConverter);
+            Add(JsonMetadataServices.DateTimeOffsetConverter);
+#if NETCOREAPP
+            Add(JsonMetadataServices.DateOnlyConverter);
+            Add(JsonMetadataServices.TimeOnlyConverter);
+#endif
+            Add(JsonMetadataServices.DoubleConverter);
+            Add(JsonMetadataServices.DecimalConverter);
+            Add(JsonMetadataServices.GuidConverter);
+            Add(JsonMetadataServices.Int16Converter);
+            Add(JsonMetadataServices.Int32Converter);
+            Add(JsonMetadataServices.Int64Converter);
+            Add(JsonMetadataServices.JsonElementConverter);
+            Add(JsonMetadataServices.JsonDocumentConverter);
+            Add(JsonMetadataServices.ObjectConverter);
+            Add(JsonMetadataServices.SByteConverter);
+            Add(JsonMetadataServices.SingleConverter);
+            Add(JsonMetadataServices.StringConverter);
+            Add(JsonMetadataServices.TimeSpanConverter);
+            Add(JsonMetadataServices.UInt16Converter);
+            Add(JsonMetadataServices.UInt32Converter);
+            Add(JsonMetadataServices.UInt64Converter);
+            Add(JsonMetadataServices.UriConverter);
+            Add(JsonMetadataServices.VersionConverter);
+
+            Debug.Assert(converters.Count <= NumberOfSimpleConverters);
+
+            return converters;
+
+            void Add(JsonConverter converter) =>
+                converters.Add(converter.TypeToConvert, converter);
+        }
+
+        internal static JsonConverter GetDefaultConverter(Type typeToConvert)
+        {
+            if (s_defaultSimpleConverters == null || s_defaultFactoryConverters == null)
+            {
+                // (De)serialization using serializer's options-based methods has not yet occurred, so the built-in converters are not rooted.
+                // Even though source-gen code paths do not call this method <i.e. JsonSerializerOptions.GetConverter(Type)>, we do not root all the
+                // built-in converters here since we fetch converters for any type included for source generation from the binded context (Priority 1).
+                ThrowHelper.ThrowNotSupportedException_BuiltInConvertersNotRooted(typeToConvert);
+                return null!;
+            }
+
+            JsonConverter? converter;
+            if (s_defaultSimpleConverters.TryGetValue(typeToConvert, out converter))
+            {
+                return converter;
+            }
+            else
+            {
+                foreach (JsonConverter item in s_defaultFactoryConverters)
+                {
+                    if (item.CanConvert(typeToConvert))
+                    {
+                        converter = item;
+                        break;
+                    }
+                }
+
+                // Since the object and IEnumerable converters cover all types, we should have a converter.
+                Debug.Assert(converter != null);
+                return converter;
+            }
+        }
+
+        internal static bool TryGetDefaultSimpleConverter(Type typeToConvert, [NotNullWhen(true)] out JsonConverter? converter)
+        {
+            if (s_defaultSimpleConverters is null)
+            {
+                converter = null;
+                return false;
+            }
+
+            return s_defaultSimpleConverters.TryGetValue(typeToConvert, out converter);
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
@@ -1,0 +1,138 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    /// <summary>
+    /// Default JsonTypeInfo resolver.
+    /// </summary>
+    public partial class DefaultJsonTypeInfoResolver : IJsonTypeInfoResolver
+    {
+        private bool _mutable;
+
+        /// <summary>
+        /// Constructs DefaultJsonTypeInfoResolver.
+        /// </summary>
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        public DefaultJsonTypeInfoResolver() : this(mutable: true)
+        {
+        }
+
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        private DefaultJsonTypeInfoResolver(bool mutable)
+        {
+            _mutable = mutable;
+
+            s_defaultFactoryConverters ??= GetDefaultFactoryConverters();
+            s_defaultSimpleConverters ??= GetDefaultSimpleConverters();
+        }
+
+        /// <inheritdoc/>
+        public virtual JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _mutable = false;
+
+            JsonTypeInfo.ValidateType(type, null, null, options);
+            JsonTypeInfo typeInfo = CreateJsonTypeInfo(type, options);
+
+            if (_modifiers != null)
+            {
+                foreach (Action<JsonTypeInfo> modifier in _modifiers)
+                {
+                    modifier(typeInfo);
+                }
+            }
+
+            return typeInfo;
+        }
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "The ctor is marked RequiresUnreferencedCode.")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "The ctor is marked RequiresDynamicCode.")]
+        private JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options)
+        {
+            MethodInfo methodInfo = typeof(DefaultJsonTypeInfoResolver).GetMethod(nameof(CreateReflectionJsonTypeInfo), BindingFlags.NonPublic | BindingFlags.Static)!;
+#if NETCOREAPP
+            return (JsonTypeInfo)methodInfo.MakeGenericMethod(type).Invoke(null, BindingFlags.NonPublic | BindingFlags.DoNotWrapExceptions, null, new[] { options }, null)!;
+#else
+            try
+            {
+                return (JsonTypeInfo)methodInfo.MakeGenericMethod(type).Invoke(null, new[] { options })!;
+            }
+            catch (TargetInvocationException ex)
+            {
+                // Some of the validation is done during construction (i.e. validity of JsonConverter, inner types etc.)
+                // therefore we need to unwrap TargetInvocationException for better user experience
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw null!;
+            }
+#endif
+        }
+
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        private static JsonTypeInfo<T> CreateReflectionJsonTypeInfo<T>(JsonSerializerOptions options) => new ReflectionJsonTypeInfo<T>(options);
+
+        /// <summary>
+        /// List of JsonTypeInfo modifiers. Modifying callbacks are called consecutively after initial resolution
+        /// and cannot be changed after GetTypeInfo is called.
+        /// </summary>
+        public IList<Action<JsonTypeInfo>> Modifiers => _modifiers ??= new ModifierCollection(this);
+        private ModifierCollection? _modifiers;
+
+        private sealed class ModifierCollection : ConfigurationList<Action<JsonTypeInfo>>
+        {
+            private readonly DefaultJsonTypeInfoResolver _resolver;
+
+            public ModifierCollection(DefaultJsonTypeInfoResolver resolver)
+            {
+                _resolver = resolver;
+            }
+
+            protected override bool IsLockedInstance => !_resolver._mutable;
+            protected override void VerifyMutable()
+            {
+                if (!_resolver._mutable)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_TypeInfoResolverImmutable();
+                }
+            }
+        }
+
+        internal static DefaultJsonTypeInfoResolver? DefaultInstance => s_defaultInstance;
+        private static DefaultJsonTypeInfoResolver? s_defaultInstance;
+
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        internal static DefaultJsonTypeInfoResolver RootDefaultInstance()
+        {
+            if (s_defaultInstance is DefaultJsonTypeInfoResolver result)
+            {
+                return result;
+            }
+
+            var newInstance = new DefaultJsonTypeInfoResolver(mutable: false);
+            DefaultJsonTypeInfoResolver? originalInstance = Interlocked.CompareExchange(ref s_defaultInstance, newInstance, comparand: null);
+            return originalInstance ?? newInstance;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonTypeInfoResolver.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    /// <summary>
+    /// Exposes method for resolving Type into JsonTypeInfo for given options.
+    /// </summary>
+    public interface IJsonTypeInfoResolver
+    {
+        /// <summary>
+        /// Resolves Type into JsonTypeInfo which defines serialization and deserialization logic.
+        /// </summary>
+        /// <param name="type">Type to be resolved.</param>
+        /// <param name="options">JsonSerializerOptions instance defining resolution parameters.</param>
+        /// <returns>Returns JsonTypeInfo instance or null if the resolver cannot produce metadata for this type.</returns>
+        JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options);
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
@@ -264,7 +264,7 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowArgumentNullException(nameof(underlyingTypeInfo));
             }
 
-            JsonConverter<T>? underlyingConverter = underlyingTypeInfo.PropertyInfoForTypeInfo?.ConverterBase as JsonConverter<T>;
+            JsonConverter<T>? underlyingConverter = underlyingTypeInfo.Converter as JsonConverter<T>;
             if (underlyingConverter == null)
             {
                 throw new InvalidOperationException(SR.Format(SR.SerializationConverterNotCompatible, underlyingConverter, typeof(T)));

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
@@ -49,16 +49,6 @@ namespace System.Text.Json.Serialization.Metadata
                 throw new ArgumentException(nameof(propertyInfo.PropertyName));
             }
 
-            JsonConverter? converter = propertyInfo.Converter;
-            if (converter == null)
-            {
-                converter = propertyTypeInfo.PropertyInfoForTypeInfo.ConverterBase as JsonConverter<T>;
-                if (converter == null)
-                {
-                    throw new InvalidOperationException(SR.Format(SR.ConverterForPropertyMustBeValid, declaringType, propertyName, typeof(T)));
-                }
-            }
-
             if (!propertyInfo.IsProperty && propertyInfo.IsVirtual)
             {
                 throw new InvalidOperationException(SR.Format(SR.FieldCannotBeVirtual, nameof(propertyInfo.IsProperty), nameof(propertyInfo.IsVirtual)));

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
@@ -61,7 +61,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             PropertyType = matchingProperty.PropertyType;
             NameAsUtf8Bytes = matchingProperty.NameAsUtf8Bytes!;
-            ConverterBase = matchingProperty.ConverterBase;
+            ConverterBase = matchingProperty.EffectiveConverter;
             IgnoreDefaultValuesOnRead = matchingProperty.IgnoreDefaultValuesOnRead;
             NumberHandling = matchingProperty.EffectiveNumberHandling;
             MatchingPropertyCanBeNull = matchingProperty.PropertyTypeCanBeNull;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -10,7 +10,7 @@ using System.Threading;
 
 namespace System.Text.Json.Serialization.Metadata
 {
-    public partial class JsonTypeInfo
+    public abstract partial class JsonTypeInfo
     {
         /// <summary>
         /// Cached typeof(object). It is faster to cache this than to call typeof(object) multiple times.
@@ -59,7 +59,9 @@ namespace System.Text.Json.Serialization.Metadata
             JsonConverter converter,
             JsonSerializerOptions options,
             JsonIgnoreCondition? ignoreCondition = null,
-            JsonTypeInfo? jsonTypeInfo = null)
+            JsonTypeInfo? jsonTypeInfo = null,
+            JsonConverter? customConverter = null,
+            bool isCustomProperty = false)
         {
             // Create the JsonPropertyInfo instance.
             JsonPropertyInfo jsonPropertyInfo = converter.CreateJsonPropertyInfo();
@@ -73,7 +75,10 @@ namespace System.Text.Json.Serialization.Metadata
                 converter,
                 ignoreCondition,
                 options,
-                jsonTypeInfo);
+                jsonTypeInfo,
+                isCustomProperty: isCustomProperty);
+
+            jsonPropertyInfo.CustomConverter = customConverter;
 
             return jsonPropertyInfo;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -14,18 +14,66 @@ namespace System.Text.Json.Serialization.Metadata
     /// <summary>
     /// Provides JSON serialization-related metadata about a type.
     /// </summary>
-    /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public partial class JsonTypeInfo
+    public abstract partial class JsonTypeInfo
     {
         internal const string JsonObjectTypeName = "System.Text.Json.Nodes.JsonObject";
 
-        internal delegate object? ConstructorDelegate();
-
         internal delegate T ParameterizedConstructorDelegate<T, TArg0, TArg1, TArg2, TArg3>(TArg0 arg0, TArg1 arg1, TArg2 arg2, TArg3 arg3);
 
-        internal ConstructorDelegate? CreateObject { get; set; }
+        private JsonPropertyDictionary<JsonPropertyInfo>.ValueList? _properties;
+
+        /// <summary>
+        /// Object constructor. If set to null type is not deserializable.
+        /// </summary>
+        public Func<object>? CreateObject
+        {
+            get => _createObject;
+            set
+            {
+                SetCreateObject(value);
+            }
+        }
+
+        private protected abstract void SetCreateObject(Delegate? createObject, bool useForExtensionDataProperty = false);
+        private protected Func<object>? _createObject;
+
+        // this is only assigned if Kind == None
+        internal Func<object>? CreateObjectForExtensionDataProperty { get; set; }
+
+        /// <summary>
+        /// Gets JsonPropertyInfo list. Only applicable when Kind is Object.
+        /// </summary>
+        public IList<JsonPropertyInfo> Properties
+        {
+            get
+            {
+                if (_properties != null)
+                {
+                    return _properties;
+                }
+
+                if (Kind == JsonTypeInfoKind.Object)
+                {
+                    // We need to ensure SourceGen had a chance to add properties
+                    LateAddProperties();
+                }
+
+                PropertyCache ??= CreatePropertyCache(capacity: 0);
+
+                if (_isConfigured || Kind != JsonTypeInfoKind.Object)
+                {
+                    // We do not pass getKey to ensure list is read-only
+                    _properties = PropertyCache.CreateValueList(getKey: null);
+                }
+                else
+                {
+                    _properties = PropertyCache.CreateValueList(getKey: (prop) => prop.Name);
+                }
+
+                return _properties;
+            }
+        }
 
         internal object? CreateObjectWithArgs { get; set; }
 
@@ -51,7 +99,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             if (ThrowOnDeserialize)
             {
-                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(Options.JsonSerializerContext, Type);
+                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(Options.SerializerContext, Type);
             }
         }
 
@@ -134,9 +182,30 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal Type? KeyType { get; set; }
 
-        internal JsonSerializerOptions Options { get; set; }
+        /// <summary>
+        /// Options associated with JsonTypeInfo
+        /// </summary>
+        public JsonSerializerOptions Options { get; private set; }
 
-        internal Type Type { get; private set; }
+        /// <summary>
+        /// Type associated with JsonTypeInfo
+        /// </summary>
+        public Type Type { get; private set; }
+
+        /// <summary>
+        /// Converter associated with the type for the given options instance
+        /// </summary>
+        public JsonConverter Converter
+            // For JsonTypeInfo CustomConverter is always null
+            // while NonCustomConverter always contains final converter.
+            // This property can be used before JsonTypeInfo is configured (especially in SourceGen case)
+            // therefore it's safer to return NonCustomConverter rather than EffectiveConverter.
+            => PropertyInfoForTypeInfo.NonCustomConverter!;
+
+        /// <summary>
+        /// Determines the kind of contract metadata current JsonTypeInfo instance is customizing
+        /// </summary>
+        public JsonTypeInfoKind Kind { get; private set; }
 
         /// <summary>
         /// The JsonPropertyInfo for this JsonTypeInfo. It is used to obtain the converter for the TypeInfo.
@@ -162,7 +231,20 @@ namespace System.Text.Json.Serialization.Metadata
         internal DefaultValueHolder DefaultValueHolder => _defaultValueHolder ??= DefaultValueHolder.CreateHolder(Type);
         private DefaultValueHolder? _defaultValueHolder;
 
-        internal JsonNumberHandling? NumberHandling { get; set; }
+        /// <summary>
+        /// Type specific value overriding JsonSerializerOptions NumberHandling. For DefaultJsonTypeInfoResolver it is equivalent to JsonNumberHandlingAttribute value.
+        /// </summary>
+        public JsonNumberHandling? NumberHandling
+        {
+            get => _numberHandling;
+            set
+            {
+                CheckMutable();
+                _numberHandling = value;
+            }
+        }
+
+        private JsonNumberHandling? _numberHandling;
 
         internal JsonTypeInfo(Type type, JsonConverter converter, JsonSerializerOptions options)
         {
@@ -192,6 +274,16 @@ namespace System.Text.Json.Serialization.Metadata
                     Debug.Fail($"Unexpected class type: {PropertyInfoForTypeInfo.ConverterStrategy}");
                     throw new InvalidOperationException();
             }
+
+            Kind = GetTypeInfoKind(type, PropertyInfoForTypeInfo.ConverterStrategy);
+        }
+
+        private protected void CheckMutable()
+        {
+            if (_isConfigured)
+            {
+                ThrowHelper.ThrowInvalidOperationException_TypeInfoImmutable();
+            }
         }
 
         private volatile bool _isConfigured;
@@ -216,34 +308,50 @@ namespace System.Text.Json.Serialization.Metadata
         internal virtual void Configure()
         {
             Debug.Assert(Monitor.IsEntered(_configureLock), "Configure called directly, use EnsureConfigured which locks this method");
-            JsonConverter converter = PropertyInfoForTypeInfo.ConverterBase;
-            Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == PropertyInfoForTypeInfo.ConverterBase.ConverterStrategy,
-                $"ConverterStrategy from PropertyInfoForTypeInfo.ConverterStrategy ({PropertyInfoForTypeInfo.ConverterStrategy}) does not match converter's ({PropertyInfoForTypeInfo.ConverterBase.ConverterStrategy})");
+
+            PropertyInfoForTypeInfo.EnsureConfigured(this);
+
+            JsonConverter converter = Converter;
+            Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == Converter.ConverterStrategy,
+                $"ConverterStrategy from PropertyInfoForTypeInfo.ConverterStrategy ({PropertyInfoForTypeInfo.ConverterStrategy}) does not match converter's ({Converter.ConverterStrategy})");
 
             converter.ConfigureJsonTypeInfo(this, Options);
-            PropertyInfoForTypeInfo.DeclaringTypeNumberHandling = NumberHandling;
-            PropertyInfoForTypeInfo.EnsureConfigured();
 
-            // Source gen currently when initializes properties
-            // also assigns JsonPropertyInfo's JsonTypeInfo which causes SO if there are any
-            // cycles in the object graph. For that reason properties cannot be added immediately.
-            // This is a no-op for ReflectionJsonTypeInfo
-            LateAddProperties();
-
-            DataExtensionProperty?.EnsureConfigured();
-
-            if (converter.ConverterStrategy == ConverterStrategy.Object && PropertyCache != null)
+            if (_properties != null)
             {
+                // If user tried to access Properties for something else than JsonTypeInfoKind.Object
+                // Properties will already be read-only
+                if (!_properties.IsReadOnly)
+                {
+                    _properties.FinishEditingAndMakeReadOnly();
+                }
+            }
+            else
+            {
+                // Resolver didn't modify properties
+
+                // Source gen currently when initializes properties
+                // also assigns JsonPropertyInfo's JsonTypeInfo which causes SO if there are any
+                // cycles in the object graph. For that reason properties cannot be added immediately.
+                // This is a no-op for ReflectionJsonTypeInfo
+                LateAddProperties();
+            }
+
+            DataExtensionProperty?.EnsureConfigured(this);
+
+            if (converter.ConverterStrategy == ConverterStrategy.Object)
+            {
+                PropertyCache ??= CreatePropertyCache(capacity: 0);
+
                 foreach (var jsonPropertyInfoKv in PropertyCache.List)
                 {
                     JsonPropertyInfo jsonPropertyInfo = jsonPropertyInfoKv.Value!;
-                    jsonPropertyInfo.DeclaringTypeNumberHandling = NumberHandling;
-                    jsonPropertyInfo.EnsureConfigured();
+                    jsonPropertyInfo.EnsureConfigured(this);
                 }
 
                 if (converter.ConstructorIsParameterized)
                 {
-                    InitializeConstructorParameters(GetParameterInfoValues(), sourceGenMode: Options.JsonSerializerContext != null);
+                    InitializeConstructorParameters(GetParameterInfoValues(), sourceGenMode: Options.SerializerContext != null);
                 }
             }
         }
@@ -290,12 +398,65 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal virtual void LateAddProperties() { }
 
-        internal virtual JsonParameterInfoValues[] GetParameterInfoValues()
+        /// <summary>
+        /// Creates JsonTypeInfo
+        /// </summary>
+        /// <typeparam name="T">Type for which JsonTypeInfo stores metadata for</typeparam>
+        /// <param name="options">Options associated with JsonTypeInfo</param>
+        /// <returns>JsonTypeInfo instance</returns>
+        public static JsonTypeInfo<T> CreateJsonTypeInfo<T>(JsonSerializerOptions options)
         {
-            // If JsonTypeInfo becomes abstract this should be abstract as well
-            Debug.Fail("This should never be called.");
-            return null!;
+            return new CustomJsonTypeInfo<T>(options);
         }
+
+        private static MethodInfo? s_createJsonTypeInfo;
+
+        /// <summary>
+        /// Creates JsonTypeInfo
+        /// </summary>
+        /// <param name="type">Type for which JsonTypeInfo stores metadata for</param>
+        /// <param name="options">Options associated with JsonTypeInfo</param>
+        /// <returns>JsonTypeInfo instance</returns>
+        [RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
+        [RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
+        public static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options)
+        {
+            s_createJsonTypeInfo ??= typeof(JsonTypeInfo).GetMethod(nameof(CreateJsonTypeInfo), new Type[] { typeof(JsonSerializerOptions) })!;
+            return (JsonTypeInfo)s_createJsonTypeInfo.MakeGenericMethod(type)
+                .Invoke(null, new object[] { options })!;
+        }
+
+        /// <summary>
+        /// Creates JsonPropertyInfo
+        /// </summary>
+        /// <param name="propertyType">Type of the property</param>
+        /// <param name="name">Name of the property</param>
+        /// <returns>JsonPropertyInfo instance</returns>
+        public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name)
+        {
+            ValidateType(propertyType, Type, null, Options);
+
+            JsonConverter converter = GetConverter(propertyType,
+                parentClassType: null,
+                memberInfo: null,
+                options: Options,
+                out _);
+
+            JsonPropertyInfo propertyInfo = CreateProperty(
+                declaredPropertyType: propertyType,
+                memberInfo: null,
+                parentClassType: Type,
+                isVirtual: false,
+                converter: converter,
+                options: Options,
+                isCustomProperty: true);
+
+            propertyInfo.Name = name;
+
+            return propertyInfo;
+        }
+
+        internal abstract JsonParameterInfoValues[] GetParameterInfoValues();
 
         internal void CacheMember(JsonPropertyInfo jsonPropertyInfo, JsonPropertyDictionary<JsonPropertyInfo>? propertyCache, ref Dictionary<string, JsonPropertyInfo>? ignoredMembers)
         {
@@ -506,6 +667,42 @@ namespace System.Text.Json.Serialization.Metadata
             return typeIsValid && Options.GetConverterInternal(memberType) != null;
         }
 
+        internal JsonPropertyDictionary<JsonPropertyInfo> CreatePropertyCache(int capacity)
+        {
+            return new JsonPropertyDictionary<JsonPropertyInfo>(Options.PropertyNameCaseInsensitive, capacity);
+        }
+
+        // This method gets the runtime information for a given type or property.
+        // The runtime information consists of the following:
+        // - class type,
+        // - element type (if the type is a collection),
+        // - the converter (either native or custom), if one exists.
+        internal static JsonConverter GetConverter(
+            Type type,
+            Type? parentClassType,
+            MemberInfo? memberInfo,
+            JsonSerializerOptions options,
+            out JsonConverter? customConverter)
+        {
+            Debug.Assert(type != null);
+            Debug.Assert(!IsInvalidForSerialization(type), $"Type `{type.FullName}` should already be validated.");
+            customConverter = parentClassType != null ? options.GetCustomConverterFromMember(parentClassType, type, memberInfo) : null;
+            return options.GetConverterForType(type);
+        }
+
+        internal static JsonConverter GetEffectiveConverter(
+            Type type,
+            Type? parentClassType,
+            MemberInfo? memberInfo,
+            JsonSerializerOptions options)
+        {
+            JsonConverter converter = GetConverter(type, parentClassType, memberInfo, options, out JsonConverter? customConverter);
+
+            customConverter = options.ExpandFactoryConverter(customConverter, type);
+
+            return customConverter ?? converter;
+        }
+
         private static JsonParameterInfo CreateConstructorParameter(
             JsonParameterInfoValues parameterInfo,
             JsonPropertyInfo jsonPropertyInfo,
@@ -517,12 +714,29 @@ namespace System.Text.Json.Serialization.Metadata
                 return JsonParameterInfo.CreateIgnoredParameterPlaceholder(parameterInfo, jsonPropertyInfo, sourceGenMode);
             }
 
-            JsonConverter converter = jsonPropertyInfo.ConverterBase;
+            JsonConverter converter = jsonPropertyInfo.EffectiveConverter;
             JsonParameterInfo jsonParameterInfo = converter.CreateJsonParameterInfo();
 
             jsonParameterInfo.Initialize(parameterInfo, jsonPropertyInfo, options);
 
             return jsonParameterInfo;
+        }
+
+        private static JsonTypeInfoKind GetTypeInfoKind(Type type, ConverterStrategy converterStrategy)
+        {
+            // System.Object is semi-polimorphic and will not respect Properties
+            if (type == typeof(object))
+            {
+                return JsonTypeInfoKind.None;
+            }
+
+            return converterStrategy switch
+            {
+                ConverterStrategy.Object => JsonTypeInfoKind.Object,
+                ConverterStrategy.Enumerable => JsonTypeInfoKind.Enumerable,
+                ConverterStrategy.Dictionary => JsonTypeInfoKind.Dictionary,
+                _ => JsonTypeInfoKind.None
+            };
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoKind.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoKind.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    /// <summary>
+    /// Determines the kind of contract metadata a given JsonTypeInfo instance is customizing
+    /// </summary>
+    public enum JsonTypeInfoKind
+    {
+        /// <summary>
+        /// Type is either a primitive value or uses a custom converter. JsonTypeInfo metadata does not apply here.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Type is serialized as object with properties
+        /// </summary>
+        Object = 1,
+        /// <summary>
+        /// Type is serialized as a collection with elements
+        /// </summary>
+        Enumerable = 2,
+        /// <summary>
+        /// Type is serialized as a dictionary with key/value pair entries
+        /// </summary>
+        Dictionary = 3
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -10,10 +10,79 @@ namespace System.Text.Json.Serialization.Metadata
     /// Provides JSON serialization-related metadata about a type.
     /// </summary>
     /// <typeparam name="T">The generic definition of the type.</typeparam>
-    [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class JsonTypeInfo<T> : JsonTypeInfo
     {
         private Action<Utf8JsonWriter, T>? _serialize;
+
+        private Func<T>? _typedCreateObject;
+
+        /// <summary>
+        /// Function for creating object before properties are set. If set to null type is not deserializable.
+        /// </summary>
+        public new Func<T>? CreateObject
+        {
+            get => _typedCreateObject;
+            set
+            {
+                SetCreateObject(value);
+            }
+        }
+
+        private protected override void SetCreateObject(Delegate? createObject, bool useForExtensionDataProperty = false)
+        {
+            Debug.Assert(createObject is null or Func<object> or Func<T>);
+
+            CheckMutable();
+
+            Func<object>? untypedCreateObject;
+            Func<T>? typedCreateObject;
+
+            if (createObject is null)
+            {
+                untypedCreateObject = null;
+                typedCreateObject = null;
+            }
+            else if (createObject is Func<T> typedDelegate)
+            {
+                if (createObject is Func<object> untypedDelegate)
+                {
+                    untypedCreateObject = untypedDelegate;
+                }
+                else
+                {
+                    // we will get here if T is value type
+                    untypedCreateObject = () => typedDelegate()!;
+                }
+
+                typedCreateObject = typedDelegate;
+            }
+            else
+            {
+                Debug.Assert(createObject is Func<object>);
+                untypedCreateObject = (Func<object>)createObject;
+                typedCreateObject = () => (T)untypedCreateObject();
+            }
+
+
+            if (Kind != JsonTypeInfoKind.None)
+            {
+                _createObject = untypedCreateObject;
+                _typedCreateObject = typedCreateObject;
+            }
+            else
+            {
+                if (useForExtensionDataProperty)
+                {
+                    CreateObjectForExtensionDataProperty = untypedCreateObject;
+                }
+                else
+                {
+                    Debug.Assert(_createObject == null);
+                    Debug.Assert(_typedCreateObject == null);
+                    ThrowHelper.ThrowInvalidOperationException_JsonTypeInfoOperationNotPossibleForKindNone();
+                }
+            }
+        }
 
         internal JsonTypeInfo(JsonConverter converter, JsonSerializerOptions options)
             : base(typeof(T), converter, options)
@@ -24,6 +93,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <see cref="JsonSourceGenerationOptionsAttribute"/> values specified at design time.
         /// </summary>
         /// <remarks>The writer is not flushed after writing.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public Action<Utf8JsonWriter, T>? SerializeHandler
         {
             get
@@ -32,6 +102,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
             private protected set
             {
+                CheckMutable();
                 _serialize = value;
                 HasSerialize = value != null;
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoResolver.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    /// <summary>
+    /// Contains utilities for IJsonTypeInfoResolver
+    /// </summary>
+    public static class JsonTypeInfoResolver
+    {
+        /// <summary>
+        /// Combines multiple IJsonTypeInfoResolvers
+        /// </summary>
+        /// <param name="resolvers"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// All resolvers except last one should return null when they do not know how to create JsonTypeInfo for a given type.
+        /// Last resolver on the list should return non-null for most of the types unless explicit type blocking is desired.
+        /// </remarks>
+        public static IJsonTypeInfoResolver Combine(params IJsonTypeInfoResolver[] resolvers)
+        {
+            return new CombiningJsonTypeInfoResolver(resolvers);
+        }
+
+        private sealed class CombiningJsonTypeInfoResolver : IJsonTypeInfoResolver
+        {
+            private readonly IJsonTypeInfoResolver[] _resolvers;
+
+            public CombiningJsonTypeInfoResolver(IJsonTypeInfoResolver[] resolvers)
+            {
+                _resolvers = resolvers.AsSpan().ToArray();
+            }
+
+            public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options)
+            {
+                foreach (IJsonTypeInfoResolver resolver in _resolvers)
+                {
+                    JsonTypeInfo? typeInfo = resolver.GetTypeInfo(type, options);
+                    if (typeInfo != null)
+                    {
+                        return typeInfo;
+                    }
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/MemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/MemberAccessor.cs
@@ -9,7 +9,7 @@ namespace System.Text.Json.Serialization.Metadata
 {
     internal abstract class MemberAccessor
     {
-        public abstract JsonTypeInfo.ConstructorDelegate? CreateConstructor(
+        public abstract Func<object>? CreateConstructor(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type classType);
 
         public abstract Func<object[], T>? CreateParameterizedConstructor<T>(ConstructorInfo constructor);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
@@ -23,7 +23,7 @@ namespace System.Text.Json.Serialization.Metadata
                     Justification = "Parent method annotation does not flow to lambda method, cf. https://github.com/dotnet/roslyn/issues/46646")]
                 static (_) => s_sourceAccessor.CreateAddMethodDelegate<TCollection>());
 
-        public override JsonTypeInfo.ConstructorDelegate? CreateConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type classType)
+        public override Func<object>? CreateConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type classType)
             => s_cache.GetOrAdd((nameof(CreateConstructor), classType, null),
                 [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
                     Justification = "Cannot apply DynamicallyAccessedMembersAttribute to tuple properties.")]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitMemberAccessor.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization.Metadata
     [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
     internal sealed class ReflectionEmitMemberAccessor : MemberAccessor
     {
-        public override JsonTypeInfo.ConstructorDelegate? CreateConstructor(
+        public override Func<object>? CreateConstructor(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
             Debug.Assert(type != null);
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             generator.Emit(OpCodes.Ret);
 
-            return (JsonTypeInfo.ConstructorDelegate)dynamicMethod.CreateDelegate(typeof(JsonTypeInfo.ConstructorDelegate));
+            return (Func<object>)dynamicMethod.CreateDelegate(typeof(Func<object>));
         }
 
         public override Func<object[], T>? CreateParameterizedConstructor<T>(ConstructorInfo constructor) =>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Metadata
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
         internal ReflectionJsonTypeInfo(JsonSerializerOptions options)
             : this(
-                  GetConverter(
+                  GetEffectiveConverter(
                     typeof(T),
                     parentClassType: null, // A TypeInfo never has a "parent" class.
                     memberInfo: null, // A TypeInfo never has a "parent" property.
@@ -40,17 +40,17 @@ namespace System.Text.Json.Serialization.Metadata
                 AddPropertiesAndParametersUsingReflection();
             }
 
-            CreateObject = Options.MemberAccessorStrategy.CreateConstructor(typeof(T));
+            SetCreateObject(Options.MemberAccessorStrategy.CreateConstructor(typeof(T)), useForExtensionDataProperty: true);
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                Justification = "The ctor is marked as RequiresUnreferencedCode")]
+            Justification = "The ctor is marked as RequiresUnreferencedCode")]
         [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
             Justification = "The ctor is marked RequiresDynamicCode.")]
         internal override void Configure()
         {
             base.Configure();
-            PropertyInfoForTypeInfo.ConverterBase.ConfigureJsonTypeInfoUsingReflection(this, Options);
+            Converter.ConfigureJsonTypeInfoUsingReflection(this, Options);
         }
 
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
@@ -72,7 +72,7 @@ namespace System.Text.Json.Serialization.Metadata
             // PropertyCache is not accessed by other threads until the current JsonTypeInfo instance
             //  is finished initializing and added to the cache on JsonSerializerOptions.
             // Default 'capacity' to the common non-polymorphic + property case.
-            PropertyCache = new JsonPropertyDictionary<JsonPropertyInfo>(Options.PropertyNameCaseInsensitive, capacity: properties.Length);
+            PropertyCache = CreatePropertyCache(capacity: properties.Length);
 
             // We start from the most derived type.
             Type? currentType = Type;
@@ -212,11 +212,13 @@ namespace System.Text.Json.Serialization.Metadata
 
             ValidateType(memberType, parentClassType, memberInfo, options);
 
+            JsonConverter? customConverter;
             JsonConverter converter = GetConverter(
                 memberType,
                 parentClassType,
                 memberInfo,
-                options);
+                options,
+                out customConverter);
 
             return CreateProperty(
                 declaredPropertyType: memberType,
@@ -225,7 +227,8 @@ namespace System.Text.Json.Serialization.Metadata
                 isVirtual,
                 converter,
                 options,
-                ignoreCondition);
+                ignoreCondition,
+                customConverter: customConverter);
         }
 
         private static JsonNumberHandling? GetNumberHandlingForType(Type type)
@@ -234,22 +237,6 @@ namespace System.Text.Json.Serialization.Metadata
                 (JsonNumberHandlingAttribute?)JsonSerializerOptions.GetAttributeThatCanHaveMultiple(type, typeof(JsonNumberHandlingAttribute));
 
             return numberHandlingAttribute?.Handling;
-        }
-
-        // This method gets the runtime information for a given type or property.
-        // The runtime information consists of the following:
-        // - class type,
-        // - element type (if the type is a collection),
-        // - the converter (either native or custom), if one exists.
-        private static JsonConverter GetConverter(
-            Type type,
-            Type? parentClassType,
-            MemberInfo? memberInfo,
-            JsonSerializerOptions options)
-        {
-            Debug.Assert(type != null);
-            Debug.Assert(!IsInvalidForSerialization(type), $"Type `{type.FullName}` should already be validated.");
-            return options.GetConverterFromMember(parentClassType, type, memberInfo);
         }
 
         private static bool PropertyIsOverridenAndIgnored(
@@ -270,7 +257,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal override JsonParameterInfoValues[] GetParameterInfoValues()
         {
-            ParameterInfo[] parameters = PropertyInfoForTypeInfo.ConverterBase.ConstructorInfo!.GetParameters();
+            ParameterInfo[] parameters = Converter.ConstructorInfo!.GetParameters();
             return GetParameterInfoArray(parameters);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionMemberAccessor.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization.Metadata
                 => Activator.CreateInstance(_type, nonPublic: false);
         }
 
-        public override JsonTypeInfo.ConstructorDelegate? CreateConstructor(
+        public override Func<object>? CreateConstructor(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
             Debug.Assert(type != null);
@@ -38,7 +38,7 @@ namespace System.Text.Json.Serialization.Metadata
                 return null;
             }
 
-            return new ConstructorContext(type).CreateInstance;
+            return new ConstructorContext(type).CreateInstance!;
         }
 
         public override Func<object[], T>? CreateParameterizedConstructor<T>(ConstructorInfo constructor)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
@@ -102,7 +102,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             JsonSerializerContext? context = Options.SerializerContext;
             JsonParameterInfoValues[] array;
-            if (context == null || CtorParamInitFunc == null || (array = CtorParamInitFunc()) == null)
+            if (CtorParamInitFunc == null || (array = CtorParamInitFunc()) == null)
             {
                 ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeCtorParams(context, Type);
                 return null!;
@@ -120,7 +120,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             JsonSerializerContext? context = Options.SerializerContext;
             JsonPropertyInfo[] array;
-            if (context == null || PropInitFunc == null || (array = PropInitFunc(context)) == null)
+            if (PropInitFunc == null || (array = PropInitFunc(context!)) == null)
             {
                 if (typeof(T) == typeof(object))
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
@@ -34,12 +34,12 @@ namespace System.Text.Json.Serialization.Metadata
             }
             else
             {
-                SetCreateObjectFunc(objectInfo.ObjectCreator);
+                SetCreateObject(objectInfo.ObjectCreator, useForExtensionDataProperty: true);
             }
-
 
             PropInitFunc = objectInfo.PropertyMetadataInitializer;
             SerializeHandler = objectInfo.SerializeHandler;
+
             NumberHandling = objectInfo.NumberHandling;
         }
 
@@ -61,11 +61,12 @@ namespace System.Text.Json.Serialization.Metadata
 
             KeyTypeInfo = collectionInfo.KeyInfo;
             ElementTypeInfo = collectionInfo.ElementInfo ?? throw new ArgumentNullException(nameof(collectionInfo.ElementInfo));
+            Debug.Assert(Kind != JsonTypeInfoKind.None);
             NumberHandling = collectionInfo.NumberHandling;
             SerializeHandler = collectionInfo.SerializeHandler;
             CreateObjectWithArgs = createObjectWithArgs;
             AddMethodDelegate = addFunc;
-            SetCreateObjectFunc(collectionInfo.ObjectCreator);
+            CreateObject = collectionInfo.ObjectCreator;
         }
 
         private static JsonConverter GetConverter(JsonObjectInfoValues<T> objectInfo)
@@ -99,7 +100,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal override JsonParameterInfoValues[] GetParameterInfoValues()
         {
-            JsonSerializerContext? context = Options.JsonSerializerContext;
+            JsonSerializerContext? context = Options.SerializerContext;
             JsonParameterInfoValues[] array;
             if (context == null || CtorParamInitFunc == null || (array = CtorParamInitFunc()) == null)
             {
@@ -117,7 +118,7 @@ namespace System.Text.Json.Serialization.Metadata
                 return;
             }
 
-            JsonSerializerContext? context = Options.JsonSerializerContext;
+            JsonSerializerContext? context = Options.SerializerContext;
             JsonPropertyInfo[] array;
             if (context == null || PropInitFunc == null || (array = PropInitFunc(context)) == null)
             {
@@ -126,13 +127,13 @@ namespace System.Text.Json.Serialization.Metadata
                     return;
                 }
 
-                if (PropertyInfoForTypeInfo.ConverterBase.ElementType != null)
+                if (Converter.ElementType != null)
                 {
                     // Nullable<> or F# optional converter's strategy is set to element's strategy
                     return;
                 }
 
-                if (SerializeHandler != null && Options.JsonSerializerContext?.CanUseSerializationLogic == true)
+                if (SerializeHandler != null && Options.SerializerContext?.CanUseSerializationLogic == true)
                 {
                     ThrowOnDeserialize = true;
                     return;
@@ -143,7 +144,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             Dictionary<string, JsonPropertyInfo>? ignoredMembers = null;
-            JsonPropertyDictionary<JsonPropertyInfo> propertyCache = new(Options.PropertyNameCaseInsensitive, array.Length);
+            JsonPropertyDictionary<JsonPropertyInfo> propertyCache = CreatePropertyCache(capacity: array.Length);
 
             for (int i = 0; i < array.Length; i++)
             {
@@ -180,14 +181,6 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             PropertyCache = propertyCache;
-        }
-
-        private void SetCreateObjectFunc(Func<T>? createObjectFunc)
-        {
-            if (createObjectFunc != null)
-            {
-                CreateObject = () => createObjectFunc();
-            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -226,7 +226,7 @@ namespace System.Text.Json
             Current.PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryStarted;
             SetConstructorArgumentState();
 
-            return derivedJsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase;
+            return derivedJsonTypeInfo.Converter;
         }
 
 
@@ -241,7 +241,7 @@ namespace System.Text.Json
             // Swap out the two values as we resume the polymorphic converter
             (Current.JsonTypeInfo, Current.PolymorphicJsonTypeInfo) = (Current.PolymorphicJsonTypeInfo, Current.JsonTypeInfo);
             Current.PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryStarted;
-            return Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase;
+            return Current.JsonTypeInfo.Converter;
         }
 
         /// <summary>
@@ -382,20 +382,20 @@ namespace System.Text.Json
 
             for (int i = 0; i < _count - 1; i++)
             {
-                if (_stack[i].JsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase.ConstructorIsParameterized)
+                if (_stack[i].JsonTypeInfo.Converter.ConstructorIsParameterized)
                 {
                     return _stack[i].JsonTypeInfo;
                 }
             }
 
-            Debug.Assert(Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase.ConstructorIsParameterized);
+            Debug.Assert(Current.JsonTypeInfo.Converter.ConstructorIsParameterized);
             return Current.JsonTypeInfo;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetConstructorArgumentState()
         {
-            if (Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase.ConstructorIsParameterized)
+            if (Current.JsonTypeInfo.Converter.ConstructorIsParameterized)
             {
                 // A zero index indicates a new stack frame.
                 if (Current.CtorArgumentStateIndex == 0)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -158,7 +158,7 @@ namespace System.Text.Json
             SupportContinuation = supportContinuation;
             SupportAsync = supportAsync;
 
-            return jsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase;
+            return jsonTypeInfo.Converter;
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -129,7 +129,7 @@ namespace System.Text.Json
             }
 
             PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryStarted;
-            return PolymorphicJsonTypeInfo.ConverterBase;
+            return PolymorphicJsonTypeInfo.EffectiveConverter;
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace System.Text.Json
 
             PolymorphicJsonTypeInfo = derivedJsonTypeInfo.PropertyInfoForTypeInfo;
             PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryStarted;
-            return PolymorphicJsonTypeInfo.ConverterBase;
+            return PolymorphicJsonTypeInfo.EffectiveConverter;
         }
 
         /// <summary>
@@ -152,7 +152,7 @@ namespace System.Text.Json
             Debug.Assert(PolymorphicSerializationState == PolymorphicSerializationState.PolymorphicReEntrySuspended);
             Debug.Assert(PolymorphicJsonTypeInfo is not null);
             PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryStarted;
-            return PolymorphicJsonTypeInfo.ConverterBase;
+            return PolymorphicJsonTypeInfo.EffectiveConverter;
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
@@ -15,18 +15,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowArgumentException_NodeArrayTooSmall(string paramName)
-        {
-            throw new ArgumentException(SR.NodeArrayTooSmall, paramName);
-        }
-
-        [DoesNotReturn]
-        public static void ThrowArgumentOutOfRangeException_NodeArrayIndexNegative(string paramName)
-        {
-            throw new ArgumentOutOfRangeException(paramName, SR.NodeArrayIndexNegative);
-        }
-
-        [DoesNotReturn]
         public static void ThrowArgumentException_DuplicateKey(string propertyName)
         {
             throw new ArgumentException(SR.NodeDuplicateKey, propertyName);
@@ -51,14 +39,14 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowNotSupportedException_NodeCollectionIsReadOnly()
+        public static void ThrowNotSupportedException_CollectionIsReadOnly()
         {
-            throw GetNotSupportedException_NodeCollectionIsReadOnly();
+            throw GetNotSupportedException_CollectionIsReadOnly();
         }
 
-        public static NotSupportedException GetNotSupportedException_NodeCollectionIsReadOnly()
+        public static NotSupportedException GetNotSupportedException_CollectionIsReadOnly()
         {
-            return new NotSupportedException(SR.NodeCollectionIsReadOnly);
+            return new NotSupportedException(SR.CollectionIsReadOnly);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -105,6 +105,18 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowInvalidOperationException_ResolverTypeNotCompatible(Type requestedType, Type actualType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.ResolverTypeNotCompatible, requestedType, actualType));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_ResolverTypeInfoOptionsNotCompatible()
+        {
+            throw new InvalidOperationException(SR.ResolverTypeInfoOptionsNotCompatible);
+        }
+
+        [DoesNotReturn]
         public static void ThrowInvalidOperationException_SerializationConverterOnAttributeInvalid(Type classType, MemberInfo? memberInfo)
         {
             string location = classType.ToString();
@@ -137,6 +149,30 @@ namespace System.Text.Json
                 : SR.SerializerContextOptionsImmutable;
 
             throw new InvalidOperationException(message);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_SerializerContextOptionsImmutable()
+        {
+            throw new InvalidOperationException(SR.SerializerContextOptionsImmutable);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_TypeInfoResolverImmutable()
+        {
+            throw new InvalidOperationException(SR.TypeInfoResolverImmutable);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_TypeInfoImmutable()
+        {
+            throw new InvalidOperationException(SR.TypeInfoImmutable);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_PropertyInfoImmutable()
+        {
+            throw new InvalidOperationException(SR.PropertyInfoImmutable);
         }
 
         [DoesNotReturn]
@@ -237,6 +273,18 @@ namespace System.Text.Json
             NotSupportedException ex = new NotSupportedException(
                 SR.Format(SR.ObjectWithParameterizedCtorRefMetadataNotSupported, jsonTypeInfo.Type));
             ThrowNotSupportedException(ref state, reader, ex);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_JsonTypeInfoOperationNotPossibleForKindNone()
+        {
+            throw new InvalidOperationException(SR.JsonTypeInfoOperationNotPossibleForKindNone);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_CollectionIsReadOnly()
+        {
+            throw new InvalidOperationException(SR.CollectionIsReadOnly);
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -35,6 +35,18 @@ namespace System.Text.Json
             throw GetArgumentOutOfRangeException(parameterName, SR.CommentHandlingMustBeValid);
         }
 
+        [DoesNotReturn]
+        public static void ThrowArgumentOutOfRangeException_ArrayIndexNegative(string paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName, SR.ArrayIndexNegative);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowArgumentException_ArrayTooSmall(string paramName)
+        {
+            throw new ArgumentException(SR.ArrayTooSmall, paramName);
+        }
+
         private static ArgumentException GetArgumentException(string message)
         {
             return new ArgumentException(message);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
@@ -37,25 +38,20 @@ namespace System.Text.Json.SourceGeneration.Tests
                     Assert.Contains("JsonSerializerOptions", exAsStr);
 
                     // This test uses reflection to:
-                    // - Access JsonSerializerOptions.s_defaultSimpleConverters
-                    // - Access JsonSerializerOptions.s_defaultFactoryConverters
-                    // - Access JsonSerializerOptions.s_typeInfoCreationFunc
+                    // - Access DefaultJsonTypeInfoResolver.s_defaultSimpleConverters
+                    // - Access DefaultJsonTypeInfoResolver.s_defaultFactoryConverters
                     //
                     // If any of them changes, this test will need to be kept in sync.
 
                     // Confirm built-in converters not set.
-                    AssertFieldNull("s_defaultSimpleConverters", optionsInstance: null);
-                    AssertFieldNull("s_defaultFactoryConverters", optionsInstance: null);
+                    AssertFieldNull("s_defaultSimpleConverters");
+                    AssertFieldNull("s_defaultFactoryConverters");
 
-                    // Confirm type info dynamic creator not set.
-                    AssertFieldNull("s_typeInfoCreationFunc", optionsInstance: null);
-
-                    static void AssertFieldNull(string fieldName, JsonSerializerOptions? optionsInstance)
+                    static void AssertFieldNull(string fieldName)
                     {
-                        BindingFlags bindingFlags = BindingFlags.NonPublic | (optionsInstance == null ? BindingFlags.Static : BindingFlags.Instance);
-                        FieldInfo fieldInfo = typeof(JsonSerializerOptions).GetField(fieldName, bindingFlags);
+                        FieldInfo fieldInfo = typeof(DefaultJsonTypeInfoResolver).GetField(fieldName, BindingFlags.Static | BindingFlags.NonPublic);
                         Assert.NotNull(fieldInfo);
-                        Assert.Null(fieldInfo.GetValue(optionsInstance));
+                        Assert.Null(fieldInfo.GetValue(null));
                     }
                 }).Dispose();
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -68,6 +68,49 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Equal("Doe", person.LastName);
         }
 
+        [Fact]
+        public static void CombiningContexts_ResolveJsonTypeInfo()
+        {
+            // Basic smoke test establishing combination of JsonSerializerContext classes.
+            IJsonTypeInfoResolver combined = JsonTypeInfoResolver.Combine(NestedContext.Default, PersonJsonContext.Default);
+            var options = new JsonSerializerOptions { TypeInfoResolver = combined };
+
+            JsonTypeInfo messageInfo = combined.GetTypeInfo(typeof(JsonMessage), options);
+            Assert.IsAssignableFrom<JsonTypeInfo<JsonMessage>>(messageInfo);
+            Assert.Same(options, messageInfo.Options);
+
+            JsonTypeInfo personInfo = combined.GetTypeInfo(typeof(Person), options);
+            Assert.IsAssignableFrom<JsonTypeInfo<Person>>(personInfo);
+            Assert.Same(options, personInfo.Options);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCombiningContextsData))]
+        public static void CombiningContexts_Serialization<T>(T value, string expectedJson)
+        {
+            // Basic smoke test establishing combination of JsonSerializerContext classes.
+            IJsonTypeInfoResolver combined = JsonTypeInfoResolver.Combine(NestedContext.Default, PersonJsonContext.Default);
+            var options = new JsonSerializerOptions { TypeInfoResolver = combined };
+
+            JsonTypeInfo<T> typeInfo = (JsonTypeInfo<T>)combined.GetTypeInfo(typeof(T), options)!;
+
+            string json = JsonSerializer.Serialize(value, typeInfo);
+            JsonTestHelper.AssertJsonEqual(expectedJson, json);
+
+            json = JsonSerializer.Serialize(value, options);
+            JsonTestHelper.AssertJsonEqual(expectedJson, json);
+
+            JsonSerializer.Deserialize<T>(json, typeInfo);
+            JsonSerializer.Deserialize<T>(json, options);
+        }
+
+        public static IEnumerable<object[]> GetCombiningContextsData()
+        {
+            yield return WrapArgs(new JsonMessage { Message = "Hi" }, """{ "Message" : { "Hi" } }""");
+            yield return WrapArgs(new Person("John", "Doe"), """{ "FirstName" : "John", "LastName" : "Doe" }""");
+            static object[] WrapArgs<T>(T value, string expectedJson) => new object[] { value, expectedJson };
+        }
+
         [JsonSerializable(typeof(JsonMessage))]
         internal partial class NestedContext : JsonSerializerContext { }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -106,7 +106,7 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         public static IEnumerable<object[]> GetCombiningContextsData()
         {
-            yield return WrapArgs(new JsonMessage { Message = "Hi" }, """{ "Message" : { "Hi" } }""");
+            yield return WrapArgs(new JsonMessage { Message = "Hi" }, """{ "Message" : "Hi", "Length" : 2 }""");
             yield return WrapArgs(new Person("John", "Doe"), """{ "FirstName" : "John", "LastName" : "Doe" }""");
             static object[] WrapArgs<T>(T value, string expectedJson) => new object[] { value, expectedJson };
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -84,6 +84,30 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Same(options, personInfo.Options);
         }
 
+        [Fact]
+        public static void CombiningContexts_ResolveJsonTypeInfo_DifferentCasing()
+        {
+            IJsonTypeInfoResolver combined = JsonTypeInfoResolver.Combine(NestedContext.Default, PersonJsonContext.Default);
+            var options = new JsonSerializerOptions
+            {
+                TypeInfoResolver = combined,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+
+            Assert.NotSame(JsonNamingPolicy.CamelCase, NestedContext.Default.Options.PropertyNamingPolicy);
+            Assert.Same(JsonNamingPolicy.CamelCase, PersonJsonContext.Default.Options.PropertyNamingPolicy);
+
+            JsonTypeInfo messageInfo = combined.GetTypeInfo(typeof(JsonMessage), options);
+            Assert.Equal(2, messageInfo.Properties.Count);
+            Assert.Equal("message", messageInfo.Properties[0].Name);
+            Assert.Equal("length", messageInfo.Properties[1].Name);
+
+            JsonTypeInfo personInfo = combined.GetTypeInfo(typeof(Person), options);
+            Assert.Equal(2, personInfo.Properties.Count);
+            Assert.Equal("firstName", personInfo.Properties[0].Name);
+            Assert.Equal("lastName", personInfo.Properties[1].Name);
+        }
+
         [Theory]
         [MemberData(nameof(GetCombiningContextsData))]
         public static void CombiningContexts_Serialization<T>(T value, string expectedJson)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
@@ -371,6 +371,7 @@ namespace System.Text.Json.Serialization.Tests
                 yield return (GetProp(nameof(JsonSerializerOptions.UnknownTypeHandling)), JsonUnknownTypeHandling.JsonNode);
                 yield return (GetProp(nameof(JsonSerializerOptions.WriteIndented)), true);
                 yield return (GetProp(nameof(JsonSerializerOptions.ReferenceHandler)), ReferenceHandler.Preserve);
+                yield return (GetProp(nameof(JsonSerializerOptions.TypeInfoResolver)), new DefaultJsonTypeInfoResolver());
 
                 static PropertyInfo GetProp(string name)
                 {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.cs
@@ -196,20 +196,20 @@ namespace System.Text.Json.Serialization.Tests
                 // for reflection-based serialization should throw NotSupportedException
                 // since it can't resolve reflection-based metadata.
                 Assert.Throws<NotSupportedException>(() => converter.Write(writer, value, options));
-                Debug.Assert(writer.BytesCommitted + writer.BytesPending == 0);
+                Assert.Equal(0, writer.BytesCommitted + writer.BytesPending);
 
                 JsonSerializer.Serialize(42, options);
 
                 // Same operation should succeed when instance has been primed.
                 converter.Write(writer, value, options);
-                Debug.Assert(writer.BytesCommitted + writer.BytesPending > 0);
+                Assert.NotEqual(0, writer.BytesCommitted + writer.BytesPending);
                 writer.Reset();
 
                 // State change should not leak into unrelated options instances.
                 var options2 = new JsonSerializerOptions();
                 options2.AddContext<JsonContext>();
                 Assert.Throws<NotSupportedException>(() => converter.Write(writer, value, options2));
-                Debug.Assert(writer.BytesCommitted + writer.BytesPending == 0);
+                Assert.Equal(0, writer.BytesCommitted + writer.BytesPending);
             }).Dispose();
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonSerializerWrapper.Reflection.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonSerializerWrapper.Reflection.cs
@@ -572,7 +572,6 @@ namespace System.Text.Json.Serialization.Tests
         {
             private static readonly ConditionalWeakTable<JsonSerializerOptions, JsonSerializerOptions> s_smallBufferMap = new();
             private static readonly JsonSerializerOptions s_DefaultOptionsWithSmallBuffer = new JsonSerializerOptions { DefaultBufferSize = 1 };
-            private static readonly FieldInfo s_optionsContextField = typeof(JsonSerializerOptions).GetField("_serializerContext", BindingFlags.NonPublic | BindingFlags.Instance);
 
             public static JsonSerializerOptions ResolveOptionsInstanceWithSmallBuffer(JsonSerializerOptions? options)
             {
@@ -592,19 +591,14 @@ namespace System.Text.Json.Serialization.Tests
                     return resolvedValue;
                 }
 
-                JsonSerializerOptions smallBufferCopy = new JsonSerializerOptions(options) { DefaultBufferSize = 1 };
-                CopyJsonSerializerContext(options, smallBufferCopy);
+                JsonSerializerOptions smallBufferCopy = new JsonSerializerOptions(options)
+                {
+                    // Copy the resolver explicitly until https://github.com/dotnet/aspnetcore/issues/38720 is resolved.
+                    TypeInfoResolver = options.TypeInfoResolver,
+                    DefaultBufferSize = 1,
+                };
                 s_smallBufferMap.Add(options, smallBufferCopy);
                 return smallBufferCopy;
-            }
-
-            private static void CopyJsonSerializerContext(JsonSerializerOptions source, JsonSerializerOptions target)
-            {
-                JsonSerializerContext context = (JsonSerializerContext)s_optionsContextField.GetValue(source);
-                if (context != null)
-                {
-                    s_optionsContextField.SetValue(target, context);
-                }
             }
         }
     }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
@@ -1,0 +1,502 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.Json.Tests;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static partial class DefaultJsonTypeInfoResolverTests
+    {
+        [Theory]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(SomeClass))]
+        [InlineData(typeof(StructWithFourArgs))]
+        [InlineData(typeof(Dictionary<string, int>))]
+        [InlineData(typeof(DictionaryWrapper))]
+        [InlineData(typeof(List<int>))]
+        [InlineData(typeof(ListWrapper))]
+        public static void TypeInfoPropertiesDefaults(Type type)
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            JsonSerializerOptions o = new();
+            o.Converters.Add(new CustomThrowingConverter<SomeClass>());
+
+            JsonTypeInfo ti = r.GetTypeInfo(type, o);
+
+            Assert.Same(o, ti.Options);
+            Assert.NotNull(ti.Properties);
+
+            if (ti.Kind == JsonTypeInfoKind.None)
+            {
+                Assert.Null(ti.CreateObject);
+                Assert.Throws<InvalidOperationException>(() => ti.CreateObject = () => Activator.CreateInstance(type));
+            }
+            else
+            {
+                Assert.NotNull(ti.CreateObject);
+                Func<object> createObj = () => Activator.CreateInstance(type);
+                ti.CreateObject = createObj;
+                Assert.Same(createObj, ti.CreateObject);
+            }
+
+            JsonPropertyInfo property = ti.CreateJsonPropertyInfo(typeof(string), "foo");
+            Assert.NotNull(property);
+
+            if (ti.Kind == JsonTypeInfoKind.Object)
+            {
+                Assert.InRange(ti.Properties.Count, 1, 10);
+                Assert.False(ti.Properties.IsReadOnly);
+                ti.Properties.Add(property);
+                ti.Properties.Remove(property);
+            }
+            else
+            {
+                Assert.Equal(0, ti.Properties.Count);
+                Assert.True(ti.Properties.IsReadOnly);
+                Assert.Throws<InvalidOperationException>(() => ti.Properties.Add(property));
+                Assert.Throws<InvalidOperationException>(() => ti.Properties.Insert(0, property));
+                Assert.Throws<InvalidOperationException>(() => ti.Properties.Clear());
+            }
+
+            Assert.Null(ti.NumberHandling);
+            JsonNumberHandling numberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString;
+            ti.NumberHandling = numberHandling;
+            Assert.Equal(numberHandling, ti.NumberHandling);
+
+            InvokeGeneric(type, nameof(TypeInfoPropertiesDefaults_Generic), ti);
+        }
+
+        private static void TypeInfoPropertiesDefaults_Generic<T>(JsonTypeInfo<T> ti)
+        {
+            if (ti.Kind == JsonTypeInfoKind.None)
+            {
+                Assert.Null(ti.CreateObject);
+                Assert.Throws<InvalidOperationException>(() => ti.CreateObject = () => (T)Activator.CreateInstance(typeof(T)));
+            }
+            else
+            {
+                bool createObjCalled = false;
+                Assert.NotNull(ti.CreateObject);
+                Func<T> createObj = () =>
+                {
+                    createObjCalled = true;
+                    return default(T);
+                };
+
+                ti.CreateObject = createObj;
+                Assert.Same(createObj, ti.CreateObject);
+
+                JsonTypeInfo untyped = ti;
+                if (typeof(T).IsValueType)
+                {
+                    Assert.NotSame(createObj, untyped.CreateObject);
+                }
+                else
+                {
+                    Assert.Same(createObj, untyped.CreateObject);
+                }
+
+                Assert.Same(untyped.CreateObject, untyped.CreateObject);
+                Assert.Same(createObj, ti.CreateObject);
+                untyped.CreateObject();
+                Assert.True(createObjCalled);
+
+                ti.CreateObject = null;
+                Assert.Null(ti.CreateObject);
+                Assert.Null(untyped.CreateObject);
+
+                bool untypedCreateObjCalled = false;
+                Func<object> untypedCreateObj = () =>
+                {
+                    untypedCreateObjCalled = true;
+                    return default(T);
+                };
+                untyped.CreateObject = untypedCreateObj;
+                Assert.Same(untypedCreateObj, untyped.CreateObject);
+                Assert.Same(ti.CreateObject, ti.CreateObject);
+                Assert.NotSame(untypedCreateObj, ti.CreateObject);
+
+                ti.CreateObject();
+                Assert.True(untypedCreateObjCalled);
+
+                untyped.CreateObject = null;
+                Assert.Null(ti.CreateObject);
+                Assert.Null(untyped.CreateObject);
+            }
+        }
+
+        [Fact]
+        public static void TypeInfoKindNoneNumberHandlingDirect()
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            r.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(int))
+                {
+                    ti.NumberHandling = JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString;
+                }
+            });
+
+            JsonSerializerOptions o = new();
+            o.TypeInfoResolver = r;
+
+            string json = JsonSerializer.Serialize(13, o);
+            Assert.Equal(@"""13""", json);
+
+            var deserialized = JsonSerializer.Deserialize<int>(json, o);
+            Assert.Equal(13, deserialized);
+        }
+
+        [Fact]
+        public static void TypeInfoKindNoneNumberHandlingDirectThroughObject()
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            r.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(int))
+                {
+                    ti.NumberHandling = JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString;
+                }
+            });
+
+            JsonSerializerOptions o = new();
+            o.TypeInfoResolver = r;
+
+            string json = JsonSerializer.Serialize<object>(13, o);
+            Assert.Equal(@"""13""", json);
+
+            var deserialized = JsonSerializer.Deserialize<object>(json, o);
+            Assert.Equal("13", ((JsonElement)deserialized).GetString());
+        }
+
+        [Fact]
+        public static void TypeInfoKindNoneNumberHandling()
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            r.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(int) || ti.Type == typeof(object))
+                {
+                    ti.NumberHandling = JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString;
+                }
+            });
+
+            JsonSerializerOptions o = new();
+            o.TypeInfoResolver = r;
+
+            SomeClass testObj = new SomeClass()
+            {
+                ObjProp = 45,
+                IntProp = 13,
+            };
+
+            string json = JsonSerializer.Serialize(testObj, o);
+            Assert.Equal(@"{""ObjProp"":""45"",""IntProp"":""13""}", json);
+
+            var deserialized = JsonSerializer.Deserialize<SomeClass>(json, o);
+            Assert.Equal(testObj.ObjProp.ToString(), ((JsonElement)deserialized.ObjProp).GetString());
+            Assert.Equal(testObj.IntProp, deserialized.IntProp);
+        }
+
+        [Fact]
+        public static void RecursiveTypeNumberHandling()
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            r.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(SomeRecursiveClass))
+                {
+                    ti.NumberHandling = JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString;
+                }
+            });
+
+            JsonSerializerOptions o = new();
+            o.TypeInfoResolver = r;
+
+            SomeRecursiveClass testObj = new SomeRecursiveClass()
+            {
+                IntProp = 13,
+                RecursiveProperty = new SomeRecursiveClass()
+                {
+                    IntProp = 14,
+                },
+            };
+
+            string json = JsonSerializer.Serialize(testObj, o);
+            Assert.Equal(@"{""IntProp"":""13"",""RecursiveProperty"":{""IntProp"":""14"",""RecursiveProperty"":null}}", json);
+
+            var deserialized = JsonSerializer.Deserialize<SomeRecursiveClass>(json, o);
+            Assert.Equal(testObj.IntProp, deserialized.IntProp);
+            Assert.NotNull(testObj.RecursiveProperty);
+            Assert.Equal(testObj.RecursiveProperty.IntProp, deserialized.RecursiveProperty.IntProp);
+            Assert.Null(testObj.RecursiveProperty.RecursiveProperty);
+        }
+
+        [Theory]
+        [InlineData(typeof(SomeClass), typeof(object))]
+        [InlineData(typeof(object), typeof(string))]
+        [InlineData(typeof(object), typeof(int))]
+        [InlineData(typeof(string), typeof(int))]
+        [InlineData(typeof(int), typeof(string))]
+        [InlineData(typeof(int), typeof(double))]
+        public static void TypeInfoOfWrongTypeOnObject(Type expectedType, Type actualType)
+        {
+            DefaultJsonTypeInfoResolver dr = new();
+            TestResolver r = new((type, options) =>
+            {
+                if (type == expectedType)
+                {
+                    return dr.GetTypeInfo(actualType, options);
+                }
+
+                return dr.GetTypeInfo(type, options);
+            });
+
+            JsonSerializerOptions o = new();
+            o.TypeInfoResolver = r;
+
+            SomeClass testObj = new()
+            {
+                ObjProp = "test",
+            };
+
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(testObj, o));
+        }
+
+        [Fact]
+        public static void TypeInfoOfWrongOptions()
+        {
+            JsonSerializerOptions wrongOptions = new();
+            DefaultJsonTypeInfoResolver dr = new();
+            TestResolver r = new((type, options) =>
+            {
+                if (type == typeof(int))
+                {
+                    return dr.GetTypeInfo(type, wrongOptions);
+                }
+
+                return dr.GetTypeInfo(type, options);
+            });
+
+            JsonSerializerOptions o = new();
+            o.TypeInfoResolver = r;
+
+            SomeClass testObj = new()
+            {
+                IntProp = 17,
+            };
+
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(testObj, o));
+        }
+
+        [Theory]
+        [InlineData(typeof(SomeClass), typeof(object))]
+        [InlineData(typeof(object), typeof(string))]
+        [InlineData(typeof(object), typeof(int))]
+        [InlineData(typeof(int), typeof(string))]
+        [InlineData(typeof(int), typeof(double))]
+        public static void TypeInfoOfWrongTypeDirectCall(Type expectedType, Type actualType)
+        {
+            DefaultJsonTypeInfoResolver dr = new();
+            TestResolver r = new((type, options) =>
+            {
+                if (type == expectedType)
+                {
+                    return dr.GetTypeInfo(actualType, options);
+                }
+
+                return dr.GetTypeInfo(type, options);
+            });
+
+            JsonSerializerOptions o = new();
+            o.TypeInfoResolver = r;
+
+            object testObj = Activator.CreateInstance(expectedType);
+
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(testObj, expectedType, o));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTypeInfoTestData))]
+        public static void TypeInfoIsImmutableAfterFirstUsage(Type type, object testObj)
+        {
+            JsonTypeInfo typeInfo = null;
+            DefaultJsonTypeInfoResolver dr = new();
+            TestResolver r = new((typeToResolve, options) =>
+            {
+                var ret = dr.GetTypeInfo(typeToResolve, options);
+                if (typeToResolve == type)
+                {
+                    Assert.Null(typeInfo);
+                    typeInfo = ret;
+                }
+
+                return ret;
+            });
+
+            JsonSerializerOptions o = new();
+            o.TypeInfoResolver = r;
+
+            Assert.NotNull(JsonSerializer.Serialize(testObj, type, o));
+            Assert.NotNull(typeInfo);
+
+            InvokeGeneric(type, nameof(TypeInfoIsImmutableAfterFirstUsage_Generic), typeInfo);
+        }
+
+        private static void TypeInfoIsImmutableAfterFirstUsage_Generic<T>(JsonTypeInfo<T> typeInfo)
+        {
+            JsonTypeInfo untyped = typeInfo;
+
+            if (typeInfo.Kind == JsonTypeInfoKind.None)
+            {
+                Assert.Null(typeInfo.CreateObject);
+                Assert.Null(untyped.CreateObject);
+            }
+            else
+            {
+                Assert.NotNull(typeInfo.CreateObject);
+                Assert.NotNull(untyped.CreateObject);
+            }
+
+            Assert.Null(typeInfo.NumberHandling);
+
+            TestTypeInfoImmutability(typeInfo);
+        }
+
+        private static void TestTypeInfoImmutability<T>(JsonTypeInfo<T> typeInfo)
+        {
+            JsonTypeInfo untyped = typeInfo;
+            Assert.Equal(typeof(T), typeInfo.Type);
+            Assert.True(typeInfo.Converter.CanConvert(typeof(T)));
+
+            JsonPropertyInfo prop = typeInfo.CreateJsonPropertyInfo(typeof(string), "foo");
+            Assert.Throws<InvalidOperationException>(() => untyped.CreateObject = untyped.CreateObject);
+            Assert.Throws<InvalidOperationException>(() => typeInfo.CreateObject = typeInfo.CreateObject);
+            Assert.Throws<InvalidOperationException>(() => typeInfo.NumberHandling = typeInfo.NumberHandling);
+            Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Clear());
+            Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Add(prop));
+            Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Insert(0, prop));
+
+            foreach (var property in typeInfo.Properties)
+            {
+                Assert.NotNull(property.PropertyType);
+                Assert.Null(property.CustomConverter);
+                Assert.NotNull(property.Name);
+                Assert.NotNull(property.Get);
+                Assert.NotNull(property.Set);
+                Assert.Null(property.ShouldSerialize);
+                Assert.Null(typeInfo.NumberHandling);
+
+                Assert.Throws<InvalidOperationException>(() => property.CustomConverter = property.CustomConverter);
+                Assert.Throws<InvalidOperationException>(() => property.Name = property.Name);
+                Assert.Throws<InvalidOperationException>(() => property.Get = property.Get);
+                Assert.Throws<InvalidOperationException>(() => property.Set = property.Set);
+                Assert.Throws<InvalidOperationException>(() => property.ShouldSerialize = property.ShouldSerialize);
+                Assert.Throws<InvalidOperationException>(() => property.NumberHandling = property.NumberHandling);
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(object), JsonTypeInfoKind.None)]
+        [InlineData(typeof(string), JsonTypeInfoKind.None)]
+        [InlineData(typeof(int), JsonTypeInfoKind.None)]
+        [InlineData(typeof(SomeRecursiveClass) /* custom converter */, JsonTypeInfoKind.None)]
+        [InlineData(typeof(SomeClass), JsonTypeInfoKind.Object)]
+        [InlineData(typeof(DefaultJsonTypeInfoResolverTests), JsonTypeInfoKind.Object)]
+        [InlineData(typeof(StructWithFourArgs), JsonTypeInfoKind.Object)]
+        [InlineData(typeof(Dictionary<string, string>), JsonTypeInfoKind.Dictionary)]
+        [InlineData(typeof(DictionaryWrapper), JsonTypeInfoKind.Dictionary)]
+        [InlineData(typeof(List<int>), JsonTypeInfoKind.Enumerable)]
+        [InlineData(typeof(ListWrapper), JsonTypeInfoKind.Enumerable)]
+        [InlineData(typeof(int[]), JsonTypeInfoKind.Enumerable)]
+        public static void JsonTypeInfoKindIsReportedCorrectly(Type type, JsonTypeInfoKind expectedJsonTypeInfoKind)
+        {
+            InvokeGeneric(type, nameof(JsonTypeInfoKindIsReportedCorrectly_Generic), expectedJsonTypeInfoKind);
+        }
+
+        private static void JsonTypeInfoKindIsReportedCorrectly_Generic<T>(JsonTypeInfoKind expectedJsonTypeInfoKind)
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            JsonSerializerOptions o = new();
+            o.Converters.Add(new CustomThrowingConverter<SomeRecursiveClass>());
+            JsonTypeInfo ti = r.GetTypeInfo(typeof(T), o);
+            Assert.Equal(expectedJsonTypeInfoKind, ti.Kind);
+
+            ti = JsonTypeInfo.CreateJsonTypeInfo(typeof(T), o);
+            Assert.Equal(expectedJsonTypeInfoKind, ti.Kind);
+
+            ti = JsonTypeInfo.CreateJsonTypeInfo<T>(o);
+            Assert.Equal(expectedJsonTypeInfoKind, ti.Kind);
+        }
+
+        [Theory]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(SomeRecursiveClass))]
+        [InlineData(typeof(SomeClass))]
+        [InlineData(typeof(DefaultJsonTypeInfoResolverTests))]
+        [InlineData(typeof(StructWithFourArgs))]
+        [InlineData(typeof(Dictionary<string, string>))]
+        [InlineData(typeof(DictionaryWrapper))]
+        [InlineData(typeof(List<int>))]
+        [InlineData(typeof(ListWrapper))]
+        [InlineData(typeof(int[]))]
+        public static void CreateJsonTypeInfo(Type type)
+        {
+            InvokeGeneric(type, nameof(CreateJsonTypeInfo_Generic));
+        }
+
+        private static void CreateJsonTypeInfo_Generic<T>()
+        {
+            TestCreateJsonTypeInfo((o) => (JsonTypeInfo<T>)JsonTypeInfo.CreateJsonTypeInfo(typeof(T), o));
+            TestCreateJsonTypeInfo((o) => JsonTypeInfo.CreateJsonTypeInfo<T>(o));
+
+            static void TestCreateJsonTypeInfo(Func<JsonSerializerOptions, JsonTypeInfo<T>> getTypeInfo)
+            {
+                JsonSerializerOptions o = new();
+                TestCreateJsonTypeInfoInstance(o, getTypeInfo(o));
+
+                o = new JsonSerializerOptions();
+                var conv = new DummyConverter<T>();
+                o.Converters.Add(conv);
+                JsonTypeInfo<T> ti = getTypeInfo(o);
+                Assert.Same(conv, ti.Converter);
+                Assert.Equal(JsonTypeInfoKind.None, ti.Kind);
+                TestCreateJsonTypeInfoInstance(o, ti);
+            }
+
+            static void TestCreateJsonTypeInfoInstance(JsonSerializerOptions o, JsonTypeInfo<T> ti)
+            {
+                Assert.Equal(typeof(T), ti.Type);
+                Assert.NotNull(ti.Converter);
+                Assert.True(ti.Converter.CanConvert(typeof(T)));
+
+                JsonSerializer.Serialize(default(T), ti);
+
+                JsonTypeInfo untyped = ti;
+                Assert.Null(ti.CreateObject);
+                Assert.Null(untyped.CreateObject);
+
+                TestTypeInfoImmutability(ti);
+            }
+        }
+
+        public static IEnumerable<object[]> GetTypeInfoTestData()
+        {
+            yield return new object[] { typeof(string), "test" };
+            yield return new object[] { typeof(int), 13 };
+            yield return new object[] { typeof(SomeClass), new SomeClass { IntProp = 17 } };
+            yield return new object[] { typeof(SomeRecursiveClass), new SomeRecursiveClass() };
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfoApis.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfoApis.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization.Metadata;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    // TODO: recursive type, options.resolver provides different answer than what we pass in
+    // TODO: ensure converter rooting happens for APIs taking JsonTypeInfo
+    public static partial class DefaultJsonTypeInfoResolverTests
+    {
+        [Theory]
+        [InlineData(typeof(string), "value", @"""value""")]
+        [InlineData(typeof(int), 5, @"5")]
+        [MemberData(nameof(JsonSerializerSerializeWithTypeInfoOfT_TestData))]
+        public static void JsonSerializerSerializeWithTypeInfoOfT(Type type, object testObj, string expectedJson)
+        {
+            InvokeGeneric(type, nameof(JsonSerializerSerializeWithTypeInfoOfT_Generic), testObj, expectedJson);
+        }
+
+        public static IEnumerable<object[]> JsonSerializerSerializeWithTypeInfoOfT_TestData()
+        {
+            yield return new object[] { typeof(SomeClass), new SomeClass() { IntProp = 15, ObjProp = 17m }, @"{""ObjProp"":17,""IntProp"":15}" };
+        }
+
+        private static void JsonSerializerSerializeWithTypeInfoOfT_Generic<T>(T testObj, string expectedJson)
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            JsonSerializerOptions o = new();
+            o.TypeInfoResolver = r;
+            JsonTypeInfo<T> typeInfo = (JsonTypeInfo<T>)r.GetTypeInfo(typeof(T), o);
+            string json = JsonSerializer.Serialize(testObj, typeInfo);
+            Assert.Equal(expectedJson, json);
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.cs
@@ -1,0 +1,228 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Text.Json.Serialization.Metadata;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static partial class DefaultJsonTypeInfoResolverTests
+    {
+        [Fact]
+        public static void GetTypeInfoNullArguments()
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            Assert.Throws<ArgumentNullException>(() => r.GetTypeInfo(null, null));
+            Assert.Throws<ArgumentNullException>(() => r.GetTypeInfo(null, new JsonSerializerOptions()));
+            Assert.Throws<ArgumentNullException>(() => r.GetTypeInfo(typeof(string), null));
+        }
+
+        [Fact]
+        public static void ModifiersIsEmptyNonCastableIList()
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            Assert.NotNull(r.Modifiers);
+            Assert.Null(r.Modifiers as List<Action<JsonTypeInfo>>);
+            Assert.False(r.Modifiers.GetType().IsPublic);
+            Assert.Empty(r.Modifiers);
+            Assert.Equal(0, r.Modifiers.Count);
+        }
+
+        [Fact]
+        public static void ModifiersAreMutableAndInterfaceIsImplementedCorrectly()
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            Assert.Same(r.Modifiers, r.Modifiers);
+            var mods = r.Modifiers;
+
+            Action<JsonTypeInfo> el0 = (ti) => { };
+            Action<JsonTypeInfo> el1 = (ti) => { };
+            Action<JsonTypeInfo> el2 = (ti) => { };
+            Assert.NotSame(el0, el1);
+            Assert.NotSame(el1, el2);
+            IEnumerator<Action<JsonTypeInfo>> enumerator;
+
+            Assert.Equal(0, mods.Count);
+            Assert.False(mods.IsReadOnly);
+            Assert.Throws<ArgumentOutOfRangeException>(() => mods[-1]);
+            Assert.Throws<ArgumentOutOfRangeException>(() => mods[0]);
+            Assert.Throws<ArgumentOutOfRangeException>(() => mods[1]);
+
+            using (enumerator = mods.GetEnumerator())
+            {
+                Assert.False(enumerator.MoveNext());
+            }
+
+            mods.Add(el0);
+            Assert.Equal(1, mods.Count);
+            Assert.Throws<ArgumentOutOfRangeException>(() => mods[-1]);
+            Assert.Same(el0, mods[0]);
+            Assert.Throws<ArgumentOutOfRangeException>(() => mods[1]);
+
+            using (enumerator = mods.GetEnumerator())
+            {
+                Assert.True(enumerator.MoveNext());
+                Assert.Same(el0, enumerator.Current);
+                Assert.False(enumerator.MoveNext());
+            }
+
+            mods.Clear();
+            Assert.Equal(0, mods.Count);
+
+            using (enumerator = mods.GetEnumerator())
+            {
+                Assert.False(enumerator.MoveNext());
+            }
+
+            mods.Insert(0, el0);
+            Assert.Equal(1, mods.Count);
+            Assert.Same(el0, mods[0]);
+            Assert.True(mods.Remove(el0));
+            Assert.Equal(0, mods.Count);
+
+            mods.Insert(0, el1);
+            mods.Insert(0, el0);
+            Assert.Equal(2, mods.Count);
+            Assert.Same(el0, mods[0]);
+            Assert.Same(el1, mods[1]);
+            Assert.False(mods.Remove(el2));
+            mods.RemoveAt(1);
+            Assert.Equal(1, mods.Count);
+            Assert.Same(el0, mods[0]);
+        }
+
+        [Fact]
+        public static void EmptyModifiersAreImmutableAfterFirstUsage()
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            IList<Action<JsonTypeInfo>> mods = r.Modifiers;
+
+            Assert.NotNull(r.GetTypeInfo(typeof(string), new JsonSerializerOptions()));
+
+            Assert.True(mods.IsReadOnly);
+            Assert.Same(mods, r.Modifiers);
+            Assert.Equal(0, mods.Count);
+
+            Assert.Throws<InvalidOperationException>(() => mods.Add((ti) => { }));
+            Assert.Throws<InvalidOperationException>(() => mods.Insert(0, (ti) => { }));
+        }
+
+        [Fact]
+        public static void NonEmptyModifiersAreImmutableAfterFirstUsage()
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            IList<Action<JsonTypeInfo>> mods = r.Modifiers;
+            Action<JsonTypeInfo> el0 = (ti) => { };
+            Action<JsonTypeInfo> el1 = (ti) => { };
+            mods.Add(el0);
+            mods.Add(el1);
+
+            Assert.NotNull(r.GetTypeInfo(typeof(string), new JsonSerializerOptions()));
+
+            Assert.True(mods.IsReadOnly);
+            Assert.Same(mods, r.Modifiers);
+            Assert.Equal(2, mods.Count);
+
+            Assert.Throws<InvalidOperationException>(() => mods.Add((ti) => { }));
+            Assert.Throws<InvalidOperationException>(() => mods.Insert(0, (ti) => { }));
+            Assert.Throws<InvalidOperationException>(() => mods.Remove(el0));
+            Assert.Throws<InvalidOperationException>(() => mods.RemoveAt(0));
+        }
+
+        [Fact]
+        public static void ModifiersAreCalledAndModifyTypeInfos()
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            JsonTypeInfo storedTypeInfo = null;
+            bool createObjectCalled = false;
+            bool secondModifierCalled = false;
+            r.Modifiers.Add((ti) =>
+            {
+                Assert.Null(storedTypeInfo);
+                storedTypeInfo = ti;
+
+                // marker that test has modified something
+                ti.CreateObject = () =>
+                {
+                    Assert.False(createObjectCalled);
+                    createObjectCalled = true;
+
+                    // we don't care what's returned as it won't be used by deserialization
+                    return null;
+                };
+            });
+
+            r.Modifiers.Add((ti) =>
+            {
+                // this proves we've been called after first modifier
+                Assert.NotNull(storedTypeInfo);
+                Assert.Same(storedTypeInfo, ti);
+                secondModifierCalled = true;
+            });
+
+            JsonTypeInfo returnedTypeInfo = r.GetTypeInfo(typeof(InvalidOperationException), new JsonSerializerOptions());
+
+            Assert.NotNull(storedTypeInfo);
+            Assert.Same(storedTypeInfo, returnedTypeInfo);
+
+            Assert.False(createObjectCalled);
+            // we call our previously set marker
+            storedTypeInfo.CreateObject();
+
+            Assert.True(createObjectCalled);
+            Assert.True(secondModifierCalled);
+        }
+
+        private static void InvokeGeneric(Type type, string methodName, params object[] args)
+        {
+            typeof(DefaultJsonTypeInfoResolverTests)
+                .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)
+                .MakeGenericMethod(type)
+                .Invoke(null, args);
+        }
+
+        private class SomeClass
+        {
+            public object ObjProp { get; set; }
+            public int IntProp { get; set; }
+        }
+
+        private class CustomThrowingConverter<T> : JsonConverter<T>
+        {
+            public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotImplementedException();
+            public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) => throw new NotImplementedException();
+        }
+
+        private class DummyConverter<T> : JsonConverter<T>
+        {
+            public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => default(T);
+            public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) { }
+        }
+
+        private class SomeRecursiveClass
+        {
+            public int IntProp { get; set; }
+            public SomeRecursiveClass RecursiveProperty { get; set; }
+        }
+
+        private class TestResolver : IJsonTypeInfoResolver
+        {
+            private Func<Type, JsonSerializerOptions, JsonTypeInfo> _getTypeInfo;
+
+            public TestResolver(Func<Type, JsonSerializerOptions, JsonTypeInfo> getTypeInfo)
+            {
+                _getTypeInfo = getTypeInfo;
+            }
+
+            public JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
+            {
+                return _getTypeInfo(type, options);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/MetadataTests.Options.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/MetadataTests.Options.cs
@@ -55,9 +55,9 @@ namespace System.Text.Json.Serialization.Tests
             // Those options are overwritten when context is binded via options.AddContext<TContext>();
             JsonSerializerOptions options = new();
             options.AddContext<MyJsonContextThatSetsOptionsInParameterlessCtor>(); // No error.
-            FieldInfo contextField = typeof(JsonSerializerOptions).GetField("_serializerContext", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(contextField);
-            Assert.Same(options, ((JsonSerializerContext)contextField.GetValue(options)).Options);
+            FieldInfo resolverField = typeof(JsonSerializerOptions).GetField("_typeInfoResolver", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(resolverField);
+            Assert.Same(options, ((JsonSerializerContext)resolverField.GetValue(options)).Options);
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/TypeInfoResolverFunctionalTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/TypeInfoResolverFunctionalTests.cs
@@ -1,0 +1,534 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization.Metadata;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static class TypeInfoResolverFunctionalTests
+    {
+        [Fact]
+        public static void AddPrefixToEveryPropertyOfClass()
+        {
+            DefaultJsonTypeInfoResolver resolver = new();
+            resolver.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(TestClass))
+                {
+                    Assert.Equal(JsonTypeInfoKind.Object, ti.Kind);
+                    foreach (var prop in ti.Properties)
+                    {
+                        prop.Name = "renamed_" + prop.Name;
+                    }
+                }
+            });
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.IncludeFields = true;
+            options.TypeInfoResolver = resolver;
+
+            TestClass originalObj = new TestClass()
+            {
+                TestField = "test value",
+                TestProperty = 42,
+            };
+
+            string json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""renamed_TestProperty"":42,""renamed_TestField"":""test value""}", json);
+
+            TestClass deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(originalObj.TestProperty, deserialized.TestProperty);
+        }
+
+        [Fact]
+        public static void AppendCharacterWhenSerializingField()
+        {
+            DefaultJsonTypeInfoResolver resolver = new();
+            resolver.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(TestClass))
+                {
+                    Assert.Equal(JsonTypeInfoKind.Object, ti.Kind);
+                    // Because IncludeFields is false
+                    Assert.Equal(1, ti.Properties.Count);
+                    JsonPropertyInfo field = ti.CreateJsonPropertyInfo(typeof(string), "TestField");
+                    field.Get = (o) =>
+                    {
+                        var obj = (TestClass)o;
+                        return obj.TestField + "X";
+                    };
+                    field.Set = (o, val) =>
+                    {
+                        var obj = (TestClass)o;
+                        var value = (string)val;
+                        // We append 'X' on serialization
+                        // therefore on deserialization we remove last character
+                        obj.TestField = value.Substring(0, value.Length - 1);
+                    };
+                    ti.Properties.Add(field);
+                }
+            });
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.TypeInfoResolver = resolver;
+
+            TestClass originalObj = new TestClass()
+            {
+                TestField = "test value",
+                TestProperty = 42,
+            };
+
+            string json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""TestProperty"":42,""TestField"":""test valueX""}", json);
+
+            TestClass deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(originalObj.TestProperty, deserialized.TestProperty);
+        }
+
+        [Fact]
+        public static void DoNotSerializeValue42()
+        {
+            DefaultJsonTypeInfoResolver resolver = new();
+            resolver.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(TestClass))
+                {
+                    Assert.Equal(JsonTypeInfoKind.Object, ti.Kind);
+                    foreach (var prop in ti.Properties)
+                    {
+                        if (prop.PropertyType == typeof(int))
+                        {
+                            prop.ShouldSerialize = (o, val) =>
+                            {
+                                return (int)val != 42;
+                            };
+                        }
+                    }
+                }
+            });
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.IncludeFields = true;
+            options.TypeInfoResolver = resolver;
+
+            TestClass originalObj = new TestClass()
+            {
+                TestField = "test value",
+                TestProperty = 43,
+            };
+
+            string json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""TestProperty"":43,""TestField"":""test value""}", json);
+
+            originalObj.TestProperty = 42;
+            json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""TestField"":""test value""}", json);
+
+            TestClass deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(0, deserialized.TestProperty);
+        }
+
+        [Fact]
+        public static void DoNotSerializePropertyWithNameButDeserializeIt()
+        {
+            DefaultJsonTypeInfoResolver resolver = new();
+            resolver.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(TestClass))
+                {
+                    Assert.Equal(JsonTypeInfoKind.Object, ti.Kind);
+                    foreach (var prop in ti.Properties)
+                    {
+                        if (prop.Name == nameof(TestClass.TestProperty))
+                        {
+                            prop.Get = null;
+                        }
+                    }
+                }
+            });
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.IncludeFields = true;
+            options.TypeInfoResolver = resolver;
+
+            TestClass originalObj = new TestClass()
+            {
+                TestField = "test value",
+                TestProperty = 42,
+            };
+
+            string json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""TestField"":""test value""}", json);
+
+            json = @"{""TestProperty"":42,""TestField"":""test value""}";
+
+            TestClass deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(originalObj.TestProperty, deserialized.TestProperty);
+        }
+
+        [Fact]
+        public static void DoNotDeserializePropertyWithNameButSerializeIt()
+        {
+            DefaultJsonTypeInfoResolver resolver = new();
+            resolver.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(TestClass))
+                {
+                    Assert.Equal(JsonTypeInfoKind.Object, ti.Kind);
+                    foreach (var prop in ti.Properties)
+                    {
+                        if (prop.Name == nameof(TestClass.TestProperty))
+                        {
+                            prop.Set = null;
+                        }
+                    }
+                }
+            });
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.IncludeFields = true;
+            options.TypeInfoResolver = resolver;
+
+            TestClass originalObj = new TestClass()
+            {
+                TestField = "test value",
+                TestProperty = 42,
+            };
+
+            string json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""TestProperty"":42,""TestField"":""test value""}", json);
+
+            TestClass deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(0, deserialized.TestProperty);
+        }
+
+        [Fact]
+        public static void SetCustomNumberHandlingForAProperty()
+        {
+            DefaultJsonTypeInfoResolver resolver = new();
+            resolver.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(TestClass))
+                {
+                    Assert.Equal(JsonTypeInfoKind.Object, ti.Kind);
+                    foreach (var prop in ti.Properties)
+                    {
+                        if (prop.Name == nameof(TestClass.TestProperty))
+                        {
+                            prop.NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString;
+                        }
+                    }
+                }
+            });
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.IncludeFields = true;
+            options.TypeInfoResolver = resolver;
+
+            TestClass originalObj = new TestClass()
+            {
+                TestField = "test value",
+                TestProperty = 42,
+            };
+
+            string json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""TestProperty"":""42"",""TestField"":""test value""}", json);
+
+            TestClass deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(originalObj.TestProperty, deserialized.TestProperty);
+        }
+
+        [Fact]
+        public static void SetCustomConverterForAProperty()
+        {
+            DefaultJsonTypeInfoResolver resolver = new();
+            resolver.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(TestClass))
+                {
+                    Assert.Equal(JsonTypeInfoKind.Object, ti.Kind);
+                    foreach (var prop in ti.Properties)
+                    {
+                        if (prop.Name == nameof(TestClass.TestProperty))
+                        {
+                            prop.CustomConverter = new PlusOneConverter();
+                        }
+                    }
+                }
+            });
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.IncludeFields = true;
+            options.TypeInfoResolver = resolver;
+
+            TestClass originalObj = new TestClass()
+            {
+                TestField = "test value",
+                TestProperty = 42,
+            };
+
+            string json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""TestProperty"":43,""TestField"":""test value""}", json);
+
+            TestClass deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(originalObj.TestProperty, deserialized.TestProperty);
+        }
+
+        [Fact]
+        public static void UntypedCreateObjectWithDefaults()
+        {
+            DefaultJsonTypeInfoResolver resolver = new();
+            resolver.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(TestClass))
+                {
+                    ti.CreateObject = () =>
+                    {
+                        return new TestClass()
+                        {
+                            TestField = "test value",
+                            TestProperty = 42,
+                        };
+                    };
+                }
+            });
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.IncludeFields = true;
+            options.TypeInfoResolver = resolver;
+
+            TestClass originalObj = new TestClass()
+            {
+                TestField = "test value 2",
+                TestProperty = 45,
+            };
+
+            string json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""TestProperty"":45,""TestField"":""test value 2""}", json);
+
+            TestClass deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(originalObj.TestProperty, deserialized.TestProperty);
+
+            json = @"{}";
+            deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal("test value", deserialized.TestField);
+            Assert.Equal(42, deserialized.TestProperty);
+
+            json = @"{""TestField"":""test value 2""}";
+            deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(42, deserialized.TestProperty);
+        }
+
+        [Fact]
+        public static void TypedCreateObjectWithDefaults()
+        {
+            DefaultJsonTypeInfoResolver resolver = new();
+            resolver.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(TestClass))
+                {
+                    JsonTypeInfo<TestClass> typedTi = ti as JsonTypeInfo<TestClass>;
+                    Assert.NotNull(typedTi);
+                    typedTi.CreateObject = () =>
+                    {
+                        return new TestClass()
+                        {
+                            TestField = "test value",
+                            TestProperty = 42,
+                        };
+                    };
+                }
+            });
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.IncludeFields = true;
+            options.TypeInfoResolver = resolver;
+
+            TestClass originalObj = new TestClass()
+            {
+                TestField = "test value 2",
+                TestProperty = 45,
+            };
+
+            string json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""TestProperty"":45,""TestField"":""test value 2""}", json);
+
+            TestClass deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(originalObj.TestProperty, deserialized.TestProperty);
+
+            json = @"{}";
+            deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal("test value", deserialized.TestField);
+            Assert.Equal(42, deserialized.TestProperty);
+
+            json = @"{""TestField"":""test value 2""}";
+            deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(42, deserialized.TestProperty);
+        }
+
+        [Fact]
+        public static void SetCustomNumberHandlingForAType()
+        {
+            DefaultJsonTypeInfoResolver resolver = new();
+            resolver.Modifiers.Add((ti) =>
+            {
+                if (ti.Type == typeof(TestClass))
+                {
+                    Assert.Equal(JsonTypeInfoKind.Object, ti.Kind);
+                    ti.NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString;
+                }
+            });
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.IncludeFields = true;
+            options.TypeInfoResolver = resolver;
+
+            TestClass originalObj = new TestClass()
+            {
+                TestField = "test value",
+                TestProperty = 42,
+            };
+
+            string json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""TestProperty"":""42"",""TestField"":""test value""}", json);
+
+            TestClass deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(originalObj.TestProperty, deserialized.TestProperty);
+        }
+
+        [Fact]
+        public static void CombineCustomResolverWithDefault()
+        {
+            TestResolver resolver = new TestResolver((Type type, JsonSerializerOptions options) =>
+            {
+                if (type != typeof(TestClass))
+                    return null;
+
+                JsonTypeInfo<TestClass> ti = JsonTypeInfo.CreateJsonTypeInfo<TestClass>(options);
+                ti.CreateObject = () => new TestClass()
+                {
+                    TestField = string.Empty,
+                    TestProperty = 42,
+                };
+
+                JsonPropertyInfo field = ti.CreateJsonPropertyInfo(typeof(string), "MyTestField");
+                field.Get = (o) =>
+                {
+                    TestClass obj = (TestClass)o;
+                    return obj.TestField ?? string.Empty;
+                };
+
+                field.Set = (o, val) =>
+                {
+                    TestClass obj = (TestClass)o;
+                    string value = (string?)val ?? string.Empty;
+                    obj.TestField = value;
+                };
+
+                field.ShouldSerialize = (o, val) => (string)val != string.Empty;
+
+                JsonPropertyInfo prop = ti.CreateJsonPropertyInfo(typeof(int), "MyTestProperty");
+                prop.Get = (o) =>
+                {
+                    TestClass obj = (TestClass)o;
+                    return obj.TestProperty;
+                };
+
+                prop.Set = (o, val) =>
+                {
+                    TestClass obj = (TestClass)o;
+                    obj.TestProperty = (int)val;
+                };
+
+                prop.ShouldSerialize = (o, val) => (int)val != 42;
+
+                ti.Properties.Add(field);
+                ti.Properties.Add(prop);
+                return ti;
+            });
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.IncludeFields = true;
+            options.TypeInfoResolver = JsonTypeInfoResolver.Combine(resolver, options.TypeInfoResolver);
+
+            TestClass originalObj = new TestClass()
+            {
+                TestField = "test value",
+                TestProperty = 45,
+            };
+
+            string json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""MyTestField"":""test value"",""MyTestProperty"":45}", json);
+
+            TestClass deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(originalObj.TestProperty, deserialized.TestProperty);
+
+            originalObj.TestField = null;
+            json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""MyTestProperty"":45}", json);
+
+            originalObj.TestField = string.Empty;
+            json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""MyTestProperty"":45}", json);
+
+            deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(originalObj.TestProperty, deserialized.TestProperty);
+
+            originalObj.TestField = "test value";
+            originalObj.TestProperty = 42;
+            json = JsonSerializer.Serialize(originalObj, options);
+            Assert.Equal(@"{""MyTestField"":""test value""}", json);
+            deserialized = JsonSerializer.Deserialize<TestClass>(json, options);
+            Assert.Equal(originalObj.TestField, deserialized.TestField);
+            Assert.Equal(originalObj.TestProperty, deserialized.TestProperty);
+        }
+
+        internal class TestClass
+        {
+            public int TestProperty { get; set; }
+            public string TestField;
+        }
+
+        internal class TestResolver : IJsonTypeInfoResolver
+        {
+            private Func<Type, JsonSerializerOptions, JsonTypeInfo?> _getTypeInfo;
+
+            public TestResolver(Func<Type, JsonSerializerOptions, JsonTypeInfo?> getTypeInfo)
+            {
+                _getTypeInfo = getTypeInfo;
+            }
+
+            public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options) => _getTypeInfo(type, options);
+        }
+
+        // adds one on write, subtracts one on read
+        internal class PlusOneConverter : JsonConverter<int>
+        {
+            public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                Assert.Equal(typeof(int), typeToConvert);
+                return reader.GetInt32() - 1;
+            }
+
+            public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+            {
+                writer.WriteNumberValue(value + 1);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/TypeInfoResolverFunctionalTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/TypeInfoResolverFunctionalTests.cs
@@ -462,7 +462,7 @@ namespace System.Text.Json.Serialization.Tests
 
             JsonSerializerOptions options = new JsonSerializerOptions();
             options.IncludeFields = true;
-            options.TypeInfoResolver = JsonTypeInfoResolver.Combine(resolver, options.TypeInfoResolver);
+            options.TypeInfoResolver = JsonTypeInfoResolver.Combine(resolver, new DefaultJsonTypeInfoResolver());
 
             TestClass originalObj = new TestClass()
             {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -170,6 +170,9 @@
     <Compile Include="Serialization\JsonPolymorphicTypeConfigurationTests.cs" />
     <Compile Include="Serialization\JsonSerializerApiValidation.cs" />
     <Compile Include="Serialization\JsonSerializerWrapper.Reflection.cs" />
+    <Compile Include="Serialization\MetadataTests\DefaultJsonTypeInfoResolverTests.JsonTypeInfoApis.cs" />
+    <Compile Include="Serialization\MetadataTests\DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs" />
+    <Compile Include="Serialization\MetadataTests\DefaultJsonTypeInfoResolverTests.cs" />
     <Compile Include="Serialization\MetadataTests\MetadataTests.cs" />
     <Compile Include="Serialization\MetadataTests\MetadataTests.JsonSerializer.cs" />
     <Compile Include="Serialization\MetadataTests\MetadataTests.Options.cs" />
@@ -196,6 +199,7 @@
     <Compile Include="Serialization\Stream.DeserializeAsyncEnumerable.cs" />
     <Compile Include="Serialization\Stream.ReadTests.cs" />
     <Compile Include="Serialization\Stream.WriteTests.cs" />
+    <Compile Include="Serialization\TypeInfoResolverFunctionalTests.cs" />
     <Compile Include="Serialization\UnsupportedTypesTests.cs" />
     <Compile Include="Serialization\Value.ReadTests.cs" />
     <Compile Include="Serialization\Value.WriteTests.cs" />

--- a/src/libraries/apicompat/ApiCompatBaseline.NetCoreAppLatestStable.txt
+++ b/src/libraries/apicompat/ApiCompatBaseline.NetCoreAppLatestStable.txt
@@ -160,4 +160,6 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.TripleDES' in the contract but not the implementation.
 Compat issues with assembly System.Security.Cryptography.X509Certificates:
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' on 'System.Security.Cryptography.X509Certificates.PublicKey.GetDSAPublicKey()' changed from '[UnsupportedOSPlatformAttribute("ios")]' in the contract to '[UnsupportedOSPlatformAttribute("browser")]' in the implementation.
-Total Issues: 149
+Compat issues with assembly System.Text.Json:
+CannotMakeTypeAbstract : Type 'System.Text.Json.Serialization.Metadata.JsonTypeInfo' is abstract in the implementation but is not abstract in the contract.
+Total Issues: 150


### PR DESCRIPTION
I think we should make this change to the property contract.